### PR TITLE
Remove tinkerforge from docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,27 +33,6 @@ services:
     depends_on:
       - pib-blockly-server
 
-  tinkerforge-brickd:
-    image: tinkerforge-brickd
-    build:
-      context: .
-      dockerfile: Dockerfile.brickd
-    privileged: true
-    profiles:
-      - all
-      - motors
-    networks:
-      - pib-network
-    ports:
-      - "4223:4223"
-    # Mount bricklets
-    devices:
-      - /dev/gpiomem:/dev/gpiomem
-    tty: true
-    restart: always
-    depends_on:
-      - flask-app
-
   rosbridge-ws:
     build:
       context: ./ros_packages


### PR DESCRIPTION
In PR-896 the tinkerforge-brickd-installation is changed to native tinkerforge instead of a dedicated container

# Jira Ticket:
<!-- Replace the last digits of the URL with your ticket number -->
Link to corresponding jira ticket:
https://pib-rocks.atlassian.net/jira/software/c/projects/PR/boards/3?selectedIssue=PR-123

# Checklist:
These tasks need to be completed before the pull request can be merged:
- [ ] The code has been reviewed and approved at least once
- [ ] All necessary tests have been successful
- [ ] The product owner reviewed and accepted the story

# Testing:
### Test acceptance criteria:
<!-- Describe when the tests are deemed successful. Remove unnecessary -->
- [ ] Example: The new Voice-Assistant-UI works as intended
- [ ] Example: All other core features work as before (Status-Quo-Test)

### Setup Tests:
<!-- Describe how the test needs to be set up. Remove unnecessary -->
A setup test was successfull on the following system(s):
- [ ] Setup on a physical pib
- [ ] Setup on a virtual machine
- [ ] Setup with docker

### Additional setup instructions:
- Example: This test requires three servo bricklets to be connected