### PR TITLE
Migrate rosbridge-ws from ROS2 Humble to Jazzy

### DIFF
--- a/ros_packages/ros_entrypoint.sh
+++ b/ros_packages/ros_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source /app/ros2_ws/install/setup.bash
 
 exec "$@"

--- a/ros_packages/rosbridge/Dockerfile
+++ b/ros_packages/rosbridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:humble-ros-core
+FROM ros:jazzy-ros-core
 
 SHELL ["/bin/bash", "-c"]
 
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY ./datatypes ros2_ws/datatypes
 
 RUN cd ros2_ws && \
-    source /opt/ros/humble/setup.bash && \
+    source /opt/ros/jazzy/setup.bash && \
     colcon build
 
 COPY ./ros_entrypoint.sh /


### PR DESCRIPTION
Changes rosbridge Dockerfile base image from ros:humble-ros-core to ros:jazzy-ros-core. Updates ros_entrypoint.sh (shared) to source /opt/ros/jazzy/setup.bash. Colcon build with Jazzy.