### PR TITLE
Migrate ros-motors from ROS2 Humble to Jazzy

### DIFF
--- a/ros_packages/motors/Dockerfile
+++ b/ros_packages/motors/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:humble-ros-core
+FROM ros:jazzy-ros-core
 
 SHELL ["/bin/bash", "-c"]
 
@@ -33,7 +33,7 @@ COPY ./ros_packages/button_service ros2_ws/button_service
 COPY ./ros_packages/motors ros2_ws/motors
 
 RUN cd ros2_ws && \
-    source /opt/ros/humble/setup.bash && \
+    source /opt/ros/jazzy/setup.bash && \
     colcon build
 
 COPY ./ros_packages/ros_entrypoint.sh /

--- a/ros_packages/motors/boot_scripts/ros_motor_boot.sh
+++ b/ros_packages/motors/boot_scripts/ros_motor_boot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 source /home/pib/ros_working_dir/ros_config.sh
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source /home/pib/ros_working_dir/install/setup.bash
 ros2 launch motors launch.py 2>&1 | tee -a ~/ros_working_dir/src/motors/motor_current.log


### PR DESCRIPTION
Changes motors Dockerfile + boot_scripts/ros_motor_boot.sh to Jazzy. Tinkerforge apt repo verified compatible.