### PR TITLE
Migrate ros-display from ROS2 Humble to Jazzy

### DIFF
--- a/ros_packages/display/Dockerfile
+++ b/ros_packages/display/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:humble-ros-core
+FROM ros:jazzy-ros-core
 
 SHELL ["/bin/bash", "-c"]
 
@@ -34,7 +34,7 @@ COPY ./ros_packages/datatypes ros2_ws/datatypes
 COPY ./ros_packages/display ros2_ws/display
 
 RUN cd ros2_ws && \
-    source /opt/ros/humble/setup.bash && \
+    source /opt/ros/jazzy/setup.bash && \
     colcon build
 
 COPY ./ros_packages/ros_entrypoint.sh /

--- a/ros_packages/display/boot_scripts/ros_display_boot.sh
+++ b/ros_packages/display/boot_scripts/ros_display_boot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 source /home/pib/ros_working_dir/ros_config.sh
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source /home/pib/ros_working_dir/install/setup.bash
 ros2 launch display launch.py 2>&1 | tee -a ~/ros_working_dir/src/display/display.log


### PR DESCRIPTION
Changes display Dockerfile + boot_scripts/ros_display_boot.sh to Jazzy. Wayland forwarding unchanged.