### PR TITLE
Migrate ros-camera from Humble to Jazzy + lightweight multi-stage image

### DIFF
--- a/ros_packages/camera/Dockerfile
+++ b/ros_packages/camera/Dockerfile
@@ -1,19 +1,38 @@
-FROM luxonis/depthai-ros:humble-arm64-latest
+FROM ros:jazzy-ros-core AS builder
+
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /app
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    python3-colcon-common-extensions \
+    python3-pip \
+    libusb-1.0-0-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY ./datatypes ros2_ws/datatypes
 COPY ./camera ros2_ws/camera
 
-RUN set -xe \
-    && apt-get update \
-    && apt-get install -y python3-pip
-
-RUN pip install depthai==2.25.1.0
-
 RUN cd ros2_ws && \
-    source /opt/ros/humble/setup.bash && \
+    source /opt/ros/jazzy/setup.bash && \
     colcon build
+
+# --- runtime stage (minimal) ---
+FROM ros:jazzy-ros-core
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python3-pip \
+    libusb-1.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir depthai==2.25.1.0
+
+WORKDIR /app
+
+COPY --from=builder /app/ros2_ws/install /app/ros2_ws/install
 
 COPY ./ros_entrypoint.sh /
 

--- a/ros_packages/camera/boot_scripts/ros_camera_boot.sh
+++ b/ros_packages/camera/boot_scripts/ros_camera_boot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source /home/pib/ros_working_dir/install/setup.bash
 source /home/pib/ros_working_dir/ros_config.sh
 ros2 run oak_d_lite stereo 2>&1 | tee -a ~/ros_working_dir/src/camera/stereo.log


### PR DESCRIPTION
Replaces luxonis/depthai-ros:humble-arm64-latest (7GB) with ros:jazzy-ros-core multi-stage build (~2GB target). boot_scripts/ros_camera_boot.sh updated.