### PR TITLE
Fix ros-motors Jazzy build — PEP 668, missing deps, GPG key

### DIFF
--- a/ros_packages/motors/Dockerfile
+++ b/ros_packages/motors/Dockerfile
@@ -6,8 +6,9 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install --no-install-recommends -y curl
 
-RUN curl -sSL https://download.tinkerforge.com/apt/$(. /etc/os-release; echo $ID)/tinkerforge.gpg | apt-key add - && \
-    echo "deb https://download.tinkerforge.com/apt/$(. /etc/os-release; echo $ID $VERSION_CODENAME) main" > /etc/apt/sources.list.d/tinkerforge.list && \
+# Tinkerforge apt repository (GPG key via signed-by, not deprecated apt-key)
+RUN curl -sSL https://download.tinkerforge.com/apt/$(. /etc/os-release; echo $ID)/tinkerforge.gpg -o /usr/share/keyrings/tinkerforge.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/tinkerforge.gpg] https://download.tinkerforge.com/apt/$(. /etc/os-release; echo $ID $VERSION_CODENAME) main" > /etc/apt/sources.list.d/tinkerforge.list && \
     apt-get update --fix-missing && \
     apt-get install --no-install-recommends -y \
         build-essential \
@@ -16,17 +17,18 @@ RUN curl -sSL https://download.tinkerforge.com/apt/$(. /etc/os-release; echo $ID
         python3-pip \
         python3-tinkerforge \
         libusb-1.0-0-dev \
+        ros-${ROS_DISTRO}-diagnostic-msgs \
+        ros-${ROS_DISTRO}-trajectory-msgs \
     && rm -rf /var/lib/apt/lists/*
 
-
-# ToDo - DEV MERGE: COPY ./ros_packages/requirements.txt .
-RUN pip install requests
+# PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
+RUN pip install --break-system-packages --no-cache-dir requests
 
 COPY ./pib_api/client ./client
-RUN pip install ./client
+RUN pip install --break-system-packages --no-cache-dir ./client
 
 COPY ./ros_packages/motors/pib_motors ./motors/pib_motors
-RUN pip install ./motors/pib_motors
+RUN pip install --break-system-packages --no-cache-dir ./motors/pib_motors
 
 COPY ./ros_packages/datatypes ros2_ws/datatypes
 COPY ./ros_packages/button_service ros2_ws/button_service

--- a/ros_packages/motors/package.xml
+++ b/ros_packages/motors/package.xml
@@ -10,6 +10,8 @@
   <exec_depend>tinkerforge</exec_depend>
   <exec_depend>button_service</exec_depend>
   <exec_depend>datatypes</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
Fixes the ros-motors Docker build failure on Jazzy.

## Changes

**Dockerfile:**
- Add `--break-system-packages` to all `pip install` (PEP 668, Python 3.12)
- Add `--no-cache-dir` to reduce image size
- Replace deprecated `apt-key` with `signed-by` GPG key approach
- Add `ros-jazzy-diagnostic-msgs` and `ros-jazzy-trajectory-msgs` apt packages
- Add `python3-pip` to apt install (not in jazzy-ros-core by default)

**package.xml:**
- Add `<exec_depend>trajectory_msgs</exec_depend>`
- Add `<exec_depend>diagnostic_msgs</exec_depend>`

## Build verified on Pi
```
datatypes — Finished [2min 9s]
button_service — Finished [18.0s]
motors — Finished [1.75s]
Summary: 3 packages finished
Image ros_motors Built
```