### PR TITLE
Fix ros-programs Jazzy build — PEP 668, docker-compose, distutils, numpy conflict

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -132,7 +132,7 @@ services:
       dockerfile: ./ros_packages/programs/Dockerfile
     command: >
       bash -lc "
-        source /opt/ros/humble/setup.bash &&
+        source /opt/ros/jazzy/setup.bash &&
         source /app/ros2_ws/install/setup.bash &&
         ros2 run button_service button_service_node &
         ros2 launch programs launch.py

--- a/pib_blockly/pib_blockly_client/setup.py
+++ b/pib_blockly/pib_blockly_client/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name="pib_blockly_client",

--- a/ros_packages/programs/Dockerfile
+++ b/ros_packages/programs/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
     python3-colcon-common-extensions \
     python3-colcon-mixin \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -16,15 +17,19 @@ COPY ./ros_packages/motors/pib_motors /tmp/pib_motors
 COPY ./ros_packages/datatypes ros2_ws/datatypes
 COPY ./ros_packages/programs ros2_ws/programs
 COPY ./ros_packages/button_service ros2_ws/button_service
-RUN apt-get update --fix-missing && \
-    apt-get install --no-install-recommends -y python3-pip && \
-    pip install /tmp/pib_blockly_client && \
-    pip install /tmp/pib_api_client && \
-    pip install /tmp/pib_motors && \
-    pip install requests==2.32.3 && \
-    pip install paramiko==3.5.1 && \
-    pip install tinkerforge && \
-    pip install opencv-python-headless "depthai<3" blobconverter
+
+# PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
+# --ignore-installed: avoid conflict with system numpy (installed by ros:jazzy-ros-core)
+RUN pip install --break-system-packages --no-cache-dir --ignore-installed \
+        /tmp/pib_blockly_client \
+        /tmp/pib_api_client \
+        /tmp/pib_motors \
+        requests==2.32.3 \
+        paramiko==3.5.1 \
+        tinkerforge \
+        opencv-python-headless \
+        "depthai<3" \
+        blobconverter
 
 RUN cd ros2_ws && \
     source /opt/ros/jazzy/setup.bash && \
@@ -33,7 +38,6 @@ RUN cd ros2_ws && \
 COPY ./ros_packages/ros_entrypoint.sh /
 
 RUN chmod +x /ros_entrypoint.sh
-
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
Fixes the ros-programs Docker build failure on Jazzy.

## Changes

**Dockerfile:**
- Add `--break-system-packages --no-cache-dir --ignore-installed` to pip install (PEP 668)
- `--ignore-installed` fixes numpy conflict: system numpy 1.26.4 (ROS) vs opencv's numpy 2.5.1
- Add `python3-pip` to apt install (not in jazzy-ros-core)
- Consolidate pip installs into single RUN for smaller image

**docker-compose.yaml:**
- Fix ros-programs command: `source /opt/ros/jazzy/setup.bash` (was still `humble`!)

**pib_blockly_client/setup.py:**
- Replace deprecated `distutils.core` with `setuptools` (removed in Python 3.12)

## Build verified on Pi
```
programs — Finished [1.61s]
datatypes — Finished [1min 47s]
button_service — Finished [32.8s]
Summary: 3 packages finished
Image ros_programs Built
```