### PR TITLE
Fix all remaining Jazzy builds — display, audio-io, voice-assistant, camera

### DIFF
--- a/ros_packages/camera/Dockerfile
+++ b/ros_packages/camera/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libusb-1.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir depthai==2.25.1.0
+# PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
+RUN pip install --break-system-packages --no-cache-dir depthai==2.25.1.0
 
 WORKDIR /app
 

--- a/ros_packages/camera/package.xml
+++ b/ros_packages/camera/package.xml
@@ -12,6 +12,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
+  <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros_packages/display/Dockerfile
+++ b/ros_packages/display/Dockerfile
@@ -21,14 +21,13 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libdbus-1-3 \
     libglib2.0-0 \
     fonts-dejavu \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
     
 WORKDIR /app
 
-RUN apt-get update --fix-missing && \
-    apt-get install --no-install-recommends -y python3-pip && \
-    pip install requests==2.32.3 && \
-    pip install pillow
+# PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
+RUN pip install --break-system-packages --no-cache-dir requests==2.32.3 pillow
 
 COPY ./ros_packages/datatypes ros2_ws/datatypes
 COPY ./ros_packages/display ros2_ws/display

--- a/ros_packages/pibsim_webots/Dockerfile
+++ b/ros_packages/pibsim_webots/Dockerfile
@@ -7,23 +7,21 @@ WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-	wget gnupg2 lsb-release ca-certificates \
+	twget gnupg2 lsb-release ca-certificates \
       && rm -rf /var/lib/apt/lists/*
 
 RUN wget -O /tmp/webots.deb \
-        https://github.com/cyberbotics/webots/releases/download/R2025a/webots_2025a_amd64.deb     
+        https://github.com/cyberbotics/webots/releases/download/R2025a/webots_2025a_amd64.deb    
 
-RUN apt-get update --fix-missing && apt-get install --no-install-recommends -y \ 
+RUN apt-get update --fix-missing && apt-get install --no-install-recommends -y \
         build-essential \
         python3-colcon-common-extensions \
         python3-colcon-mixin \
         python3-pip \
         /tmp/webots.deb \
-        ros-jazzy-webots-ros2 \
+        ros-${ROS_DISTRO}-webots-ros2 \
     && rm /tmp/webots.deb \
     && rm -rf /var/lib/apt/lists/*
-
-
 
 COPY ./ros_packages/pibsim_webots ros2_ws/pibsim_webots
 
@@ -34,7 +32,6 @@ RUN cd ros2_ws && \
 COPY ./ros_packages/ros_entrypoint.sh /
 
 RUN chmod +x /ros_entrypoint.sh
-
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/ros_packages/ros_audio_io/Dockerfile
+++ b/ros_packages/ros_audio_io/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update --fix-missing && \
     apt-get install --no-install-recommends -y \
         python3-pip \
         python3-colcon-common-extensions \
-        ros-jazzy-rclpy \
-        ros-jazzy-std-msgs \
+        ros-${ROS_DISTRO}-rclpy \
+        ros-${ROS_DISTRO}-std-msgs \
         python3-usb \
         portaudio19-dev \
         build-essential \
@@ -21,11 +21,12 @@ RUN apt-get update --fix-missing && \
         libusb-1.0-0-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python audio packages
-RUN pip install pyaudio numpy scipy taskgroup
+# PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
+# --ignore-installed: avoid conflict with system numpy (installed by ros:jazzy-ros-core)
+RUN pip install --break-system-packages --no-cache-dir --ignore-installed pyaudio numpy scipy taskgroup
 
 COPY ./pib_api/client ./client
-RUN pip install ./client
+RUN pip install --break-system-packages --no-cache-dir ./client
 
 COPY ./ros_packages/datatypes ros2_ws/datatypes
 COPY ./ros_packages/ros_audio_io ros2_ws/ros_audio_io
@@ -40,4 +41,3 @@ RUN chmod +x /ros_entrypoint.sh
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]
-

--- a/ros_packages/ros_audio_io/package.xml
+++ b/ros_packages/ros_audio_io/package.xml
@@ -12,7 +12,8 @@
   <exec_depend>pyaudio</exec_depend>
   <exec_depend>numpy</exec_depend>
   <exec_depend>scipy</exec_depend>
-  <exec_depend>rclpy</exec_depend>  
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>datatypes</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros_packages/voice_assistant/Dockerfile
+++ b/ros_packages/voice_assistant/Dockerfile
@@ -19,15 +19,14 @@ RUN apt-get update --fix-missing && \
 
 COPY ./ros_packages/requirements.txt .
 
-RUN pip install requests
-RUN pip install pyaudio
-RUN pip install google-genai
+# PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
+RUN pip install --break-system-packages --no-cache-dir requests pyaudio google-genai
 
 COPY ./pib_api/client ./client
-RUN pip install ./client
+RUN pip install --break-system-packages --no-cache-dir ./client
 
 COPY ./public_api_client ./public_api_client
-RUN pip install ./public_api_client/
+RUN pip install --break-system-packages --no-cache-dir ./public_api_client/
 
 COPY ./ros_packages/datatypes ros2_ws/datatypes
 COPY ./ros_packages/voice_assistant ros2_ws/voice_assistant

--- a/ros_packages/voice_assistant/package.xml
+++ b/ros_packages/voice_assistant/package.xml
@@ -9,6 +9,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>datatypes</exec_depend>
 
   <exec_depend>openai</exec_depend>
   <exec_depend>google-cloud-speech</exec_depend>


### PR DESCRIPTION
Fixes PEP 668 pip failures for all remaining containers.

## Dockerfiles (display, audio_io, voice_assistant, camera)
- Add --break-system-packages --no-cache-dir to all pip install (PEP 668)
- Add --ignore-installed to audio_io (numpy conflict)
- Add python3-pip to display apt (missing from jazzy-ros-core)
- Camera: add --break-system-packages to runtime stage

## package.xml
- camera: add rclpy exec_depend (was missing)
- audio_io: add datatypes exec_depend (code imports it)
- voice_assistant: add datatypes exec_depend (code imports it)

## Build verified on Pi
- Image ros-display Built
- Image ros-audio-io Built
- Image ros-voice_assistant Built