### PR TITLE
Add release-drafter for automatic release notes on develop

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,49 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - wontfix
+      - question
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+        - enhancement
+    - title: 🧪 Testing
+      labels:
+        - testing
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: ♻️ Refactoring
+      labels:
+        - refactor
+    - title: 🔧 Maintenance
+      labels:
+        - maintenance
+  template: |
+    ## Changes since $PREVIOUS_TAG
+
+    $CHANGES
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - feature
+      - enhancement
+  patch:
+    labels:
+      - bug
+      - testing
+      - documentation
+      - refactor
+      - maintenance
+  default: patch

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request_target:
+    types: [opened, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Re-adds the release-drafter config + workflow (a previous merge under the same purpose accidentally landed an unrelated .test-venv commit instead).