### PR TITLE
Fix ros-camera — cv2 missing, haarcascade missing, opencv 5.x API break

### DIFF
--- a/ros_packages/camera/Dockerfile
+++ b/ros_packages/camera/Dockerfile
@@ -26,23 +26,26 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-pip \
     libusb-1.0-0 \
-    libgl1 \
-    libglib2.0-0 \
-    libsm6 \
-    libxext6 \
-    libxrender1 \
+    curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
 # --ignore-installed: avoid conflict with system numpy (installed by ros:jazzy-ros-core)
-# opencv-python (NOT -headless): stereo.py needs cv2.data.haarcascades at
-# runtime for face detection (CameraNode raises RuntimeError and falls back
-# to the error-only publisher if the cascade XML is missing). The -headless
-# wheel's bundled cv2/data/ directory was empty on this arm64 build; the full
-# opencv-python wheel reliably ships the haarcascade XML files.
 RUN pip install --break-system-packages --no-cache-dir --ignore-installed \
         depthai==2.25.1.0 \
-        opencv-python
+        opencv-python-headless
+
+# stereo.py needs cv2.data.haarcascades at runtime for face detection
+# (CameraNode raises RuntimeError and permanently falls back to an
+# error-only publisher if the cascade XML is missing). Neither the
+# opencv-python nor opencv-python-headless PyPI wheels ship the haarcascade
+# data files on this arm64/Python 3.12 build, so fetch the XML directly from
+# the upstream OpenCV repo (same file, BSD/MIT licensed) instead of relying
+# on the wheel's bundled copy.
+RUN mkdir -p /usr/share/opencv4/haarcascades && \
+    curl -sSL -o /usr/share/opencv4/haarcascades/haarcascade_frontalface_default.xml \
+        https://raw.githubusercontent.com/opencv/opencv/4.x/data/haarcascades/haarcascade_frontalface_default.xml
 
 WORKDIR /app
 

--- a/ros_packages/camera/Dockerfile
+++ b/ros_packages/camera/Dockerfile
@@ -26,16 +26,23 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-pip \
     libusb-1.0-0 \
+    libgl1 \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
     && rm -rf /var/lib/apt/lists/*
 
 # PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
 # --ignore-installed: avoid conflict with system numpy (installed by ros:jazzy-ros-core)
-# opencv-python-headless: stereo.py imports cv2 directly (was missing from the
-# runtime stage — only depthai was installed, causing "ModuleNotFoundError: cv2"
-# and a container restart loop).
+# opencv-python (NOT -headless): stereo.py needs cv2.data.haarcascades at
+# runtime for face detection (CameraNode raises RuntimeError and falls back
+# to the error-only publisher if the cascade XML is missing). The -headless
+# wheel's bundled cv2/data/ directory was empty on this arm64 build; the full
+# opencv-python wheel reliably ships the haarcascade XML files.
 RUN pip install --break-system-packages --no-cache-dir --ignore-installed \
         depthai==2.25.1.0 \
-        opencv-python-headless
+        opencv-python
 
 WORKDIR /app
 

--- a/ros_packages/camera/Dockerfile
+++ b/ros_packages/camera/Dockerfile
@@ -32,9 +32,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # PEP 668: Jazzy (Ubuntu 24.04, Python 3.12) requires --break-system-packages
 # --ignore-installed: avoid conflict with system numpy (installed by ros:jazzy-ros-core)
+# opencv-python-headless pinned to 4.x: the latest 5.x release removed
+# cv2.CascadeClassifier from the core module (stereo.py's face detection
+# needs it), causing "module 'cv2' has no attribute 'CascadeClassifier'".
 RUN pip install --break-system-packages --no-cache-dir --ignore-installed \
         depthai==2.25.1.0 \
-        opencv-python-headless
+        "opencv-python-headless<5"
 
 # stereo.py needs cv2.data.haarcascades at runtime for face detection
 # (CameraNode raises RuntimeError and permanently falls back to an


### PR DESCRIPTION
Fixes a 3-layer bug chain that kept ros-camera permanently stuck on the error-only fallback publisher (no crash logs visible due to stdout buffering + a broad except in spin_camera()).

1. opencv-python-headless was missing from the runtime stage -> ModuleNotFoundError: cv2
2. haarcascade_frontalface_default.xml is not shipped by either opencv-python or opencv-python-headless wheels on this arm64/Python 3.12 build -> RuntimeError at CameraNode init. Fixed by fetching the XML directly from the upstream OpenCV repo into /usr/share/opencv4/haarcascades/.
3. The unpinned install resolved to opencv-python-headless 5.0.0.93, which removed cv2.CascadeClassifier from the core module -> AttributeError. Pinned to <5 (resolves to 4.13.0.92).

Verified on Pi: /camera_node registers, /get_camera_image service returns a real base64 JPEG frame from the OAK-D-Lite. Image size unchanged at ~1.05GB.