### PR TITLE
PR-1477: Blockly single-source — back-port run-script + sync Action

### DIFF
--- a/.github/workflows/sync-blockly-to-cerebra.yml
+++ b/.github/workflows/sync-blockly-to-cerebra.yml
@@ -1,0 +1,160 @@
+name: Sync Blockly to cerebra
+
+# Single source of truth: pib-backend owns all pib-blockly code (blocks + generators).
+# On any push that touches the blockly source, mirror the tree into cerebra via an
+# auto-generated pull request. See Jira PR-1477 and the KB page
+# "Blockly Code: Single-Source Architecture & Sync".
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - "pib_blockly/pib_blockly_server/src/pib-blockly/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  # one run per source branch; newer pushes cancel in-flight runs for that branch
+  group: sync-blockly-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # path mapping (PR-1477 technical notes)
+  SRC_PATH: pib_blockly/pib_blockly_server/src/pib-blockly
+  DST_PATH: src/app/program/pib-blockly
+  CEREBRA_REPO: pib-rocks/cerebra
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # main is excluded: syncs flow from feature branches and develop only
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: Checkout pib-backend (source)
+        uses: actions/checkout@v4
+        with:
+          path: pib-backend
+
+      - name: Derive branch names
+        id: names
+        run: |
+          SRC_BRANCH="${GITHUB_REF#refs/heads/}"
+          # sanitize for use as a branch segment (slashes -> dashes)
+          SAFE_BRANCH="${SRC_BRANCH//\//-}"
+          echo "src_branch=$SRC_BRANCH"          >> "$GITHUB_OUTPUT"
+          echo "sync_branch=sync/blockly-from-${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Source branch:  $SRC_BRANCH"
+          echo "Cerebra branch: sync/blockly-from-${SAFE_BRANCH}"
+
+      - name: Checkout cerebra (target)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CEREBRA_REPO }}
+          token: ${{ secrets.CEREBRA_SYNC_TOKEN }}
+          path: cerebra
+          fetch-depth: 0
+          ref: develop
+
+      - name: Prepare / reset sync branch from develop
+        working-directory: cerebra
+        run: |
+          git config user.name  "pib-sync-bot"
+          git config user.email "pib-sync-bot@users.noreply.github.com"
+          SYNC_BRANCH="${{ steps.names.outputs.sync_branch }}"
+
+          # Determine whether an OPEN PR already exists for this sync branch.
+          OPEN_PR=$(gh pr list --repo "${{ env.CEREBRA_REPO }}" \
+                      --head "$SYNC_BRANCH" --state open --json number \
+                      --jq '.[0].number // empty' 2>/dev/null || true)
+
+          if git ls-remote --exit-code --heads origin "$SYNC_BRANCH" >/dev/null 2>&1; then
+            if [ -n "$OPEN_PR" ]; then
+              # Branch exists + PR open -> update PR in place (keep branch, will force content on top)
+              echo "Existing open PR #$OPEN_PR on $SYNC_BRANCH -> updating in place."
+              git fetch origin "$SYNC_BRANCH"
+              git checkout -B "$SYNC_BRANCH" "origin/$SYNC_BRANCH"
+            else
+              # Branch exists but PR already merged/closed -> reset to fresh develop HEAD
+              echo "Branch exists but no open PR -> resetting $SYNC_BRANCH to develop HEAD."
+              git checkout -B "$SYNC_BRANCH" origin/develop
+            fi
+          else
+            # Branch missing -> (re)create from develop HEAD
+            echo "Sync branch missing -> creating $SYNC_BRANCH from develop HEAD."
+            git checkout -B "$SYNC_BRANCH" origin/develop
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.CEREBRA_SYNC_TOKEN }}
+
+      - name: Mirror blockly tree (adds, modifies, deletions)
+        run: |
+          SRC="pib-backend/${SRC_PATH}/"
+          DST="cerebra/${DST_PATH}/"
+          mkdir -p "$DST"
+          # --delete removes files in cerebra that no longer exist in pib-backend.
+          # Preserve cerebra's auto-generated README banner (managed separately).
+          rsync -a --delete \
+                --exclude 'README.md' \
+                "$SRC" "$DST"
+          echo "Mirrored $SRC -> $DST"
+
+      - name: Detect changes
+        id: diff
+        working-directory: cerebra
+        run: |
+          if git status --porcelain -- "${DST_PATH}" | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected:"
+            git status --porcelain -- "${DST_PATH}"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No differences - cerebra already in sync. No PR will be created."
+          fi
+
+      - name: Commit & push sync branch
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: cerebra
+        run: |
+          SYNC_BRANCH="${{ steps.names.outputs.sync_branch }}"
+          git add -A -- "${DST_PATH}"
+          git commit -m "chore(blockly): sync from pib-backend@${GITHUB_SHA:0:7} (${{ steps.names.outputs.src_branch }})"
+          # force-with-lease keeps an open PR updated in place; safe (re)create otherwise
+          git push --force-with-lease origin "$SYNC_BRANCH"
+
+      - name: Open or update pull request
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: cerebra
+        env:
+          GH_TOKEN: ${{ secrets.CEREBRA_SYNC_TOKEN }}
+        run: |
+          SYNC_BRANCH="${{ steps.names.outputs.sync_branch }}"
+          SRC_BRANCH="${{ steps.names.outputs.src_branch }}"
+          TITLE="chore(blockly): sync from pib-backend (${SRC_BRANCH})"
+          BODY=$(cat <<EOF
+          Automated sync of the single-source pib-blockly code.
+
+          - Source: [pib-rocks/pib-backend@\`${GITHUB_SHA:0:7}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}) on branch \`${SRC_BRANCH}\`
+          - Path: \`${SRC_PATH}\` -> \`${DST_PATH}\`
+
+          Do not edit \`${DST_PATH}\` directly in cerebra - change it in pib-backend.
+          Generated by the \`Sync Blockly to cerebra\` workflow (Jira PR-1477).
+          EOF
+          )
+
+          EXISTING=$(gh pr list --repo "${{ env.CEREBRA_REPO }}" \
+                       --head "$SYNC_BRANCH" --state open --json number \
+                       --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing PR #$EXISTING"
+            gh pr edit "$EXISTING" --repo "${{ env.CEREBRA_REPO }}" \
+               --title "$TITLE" --body "$BODY" --add-label maintenance || true
+          else
+            echo "Creating new PR"
+            gh pr create --repo "${{ env.CEREBRA_REPO }}" \
+               --base develop --head "$SYNC_BRANCH" \
+               --title "$TITLE" --body "$BODY" --label maintenance
+          fi

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/custom-blocks.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/custom-blocks.ts
@@ -8,10 +8,11 @@ import {motor_blocks} from "./motor-blocks";
 import {playAudioFromSpeech} from "./play-audio-from-speech-block";
 import {moveToPose} from "./pose-block";
 import {setSolidStateRelay} from "./solid-state-relay-block";
-import { displayBlocks } from "./display-blocks";
+import {displayBlocks} from "./display-blocks";
+import {runScriptBlocks} from "./run-script-block";
 
 export function customBlockDefinition() {
-  Blockly.common.defineBlocks(displayBlocks);
+    Blockly.common.defineBlocks(displayBlocks);
     Blockly.common.defineBlocks(time_blocks);
     Blockly.common.defineBlocks(face_detector_blocks);
     Blockly.common.defineBlocks(motor_blocks);
@@ -20,5 +21,7 @@ export function customBlockDefinition() {
     Blockly.common.defineBlocks(setSolidStateRelay);
     Blockly.common.defineBlocks(playWav);
     Blockly.common.defineBlocks(tfButton);
+    Blockly.common.defineBlocks(runScriptBlocks);
+
     face_detector_blocks["face_detector_running"].editable_ = false;
 }

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/display-blocks.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/display-blocks.ts
@@ -1,48 +1,50 @@
 import * as Blockly from "blockly";
 
-export const displayBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([
-  {
-    type: "set_face_expression",
-    message0: "Set expression %1",
-    args0: [
-      {
-        type: "field_dropdown",
-        name: "EXPRESSION",
-        options: [
-          ["Happy", "happy"],
-          ["Sad", "sad"],
-          ["Sleep", "sleep"],
-          ["Surprise", "surprise"],
-          ["Thinking", "thinking"],
-          ["Heart eyes", "heart_eyes"],
-          ["Dizzy", "dizzy"],
-          ["Angry", "angry"],
-          ["Laugh", "laugh"],
-          ["Cry", "cry"],
-        ],
-      },
+export const displayBlocks = Blockly.common.createBlockDefinitionsFromJsonArray(
+    [
+        {
+            type: "set_face_expression",
+            message0: "Set expression %1",
+            args0: [
+                {
+                    type: "field_dropdown",
+                    name: "EXPRESSION",
+                    options: [
+                        ["Happy", "happy"],
+                        ["Sad", "sad"],
+                        ["Sleep", "sleep"],
+                        ["Surprise", "surprise"],
+                        ["Thinking", "thinking"],
+                        ["Heart eyes", "heart_eyes"],
+                        ["Dizzy", "dizzy"],
+                        ["Angry", "angry"],
+                        ["Laugh", "laugh"],
+                        ["Cry", "cry"],
+                    ],
+                },
+            ],
+            previousStatement: null,
+            nextStatement: null,
+            colour: 180,
+            tooltip: "Shows an expression on Pib's face for 15 seconds.",
+            helpUrl: "",
+        },
+        {
+            type: "show_face_text",
+            message0: "Show face text %1",
+            args0: [
+                {
+                    type: "field_input",
+                    name: "TEXT",
+                    text: "Hello Pib!",
+                    spellcheck: false,
+                },
+            ],
+            previousStatement: null,
+            nextStatement: null,
+            colour: 180,
+            tooltip: "Shows short text on Pib's face. Max 40 characters.",
+            helpUrl: "",
+        },
     ],
-    previousStatement: null,
-    nextStatement: null,
-    colour: 180,
-    tooltip: "Shows an expression on Pib's face for 15 seconds.",
-    helpUrl: "",
-  },
-  {
-    type: "show_face_text",
-    message0: "Show face text %1",
-    args0: [
-      {
-        type: "field_input",
-        name: "TEXT",
-        text: "Hello Pib!",
-        spellcheck: false,
-      },
-    ],
-    previousStatement: null,
-    nextStatement: null,
-    colour: 180,
-    tooltip: "Shows short text on Pib's face. Max 40 characters.",
-    helpUrl: "",
-  },
-]);
+);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/pose-block.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/pose-block.ts
@@ -19,10 +19,10 @@ export const moveToPose = (Blockly.Blocks["move_to_pose"] = {
 });
 class CustomFieldDropdown extends Blockly.FieldDropdown {
     constructor(menuGenerator: any, opt_validator?: any, opt_config?: any) {
-      super(menuGenerator, opt_validator, opt_config);
+        super(menuGenerator, opt_validator, opt_config);
     }
     // Override the default validation function
     override doClassValidation_(newValue: any) {
-      return newValue;
+        return newValue;
     }
 }

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/run-script-block.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/run-script-block.ts
@@ -1,0 +1,177 @@
+import * as Blockly from "blockly";
+
+const DEFAULT_HOST = "localhost";
+const DEFAULT_USER = "pib";
+const DEFAULT_PASSWORD = "pib";
+const DEFAULT_PORT = 22;
+
+// Mixin that adds the "gear" mutator used to optionally expose the SSH
+// connection settings (host / user / password / port) on the block.
+const CONNECTION_MUTATOR_MIXIN = {
+    showSettings_: false,
+    host_: DEFAULT_HOST,
+    user_: DEFAULT_USER,
+    password_: DEFAULT_PASSWORD,
+    port_: DEFAULT_PORT,
+
+    saveExtraState: function (this: any) {
+        // make sure the cached values reflect the currently shown fields
+        if (this.getInput("CONNECTION")) {
+            this.host_ = this.getFieldValue("HOST") ?? this.host_;
+            this.user_ = this.getFieldValue("USER") ?? this.user_;
+            this.password_ = this.getFieldValue("PASSWORD") ?? this.password_;
+            this.port_ = Number(this.getFieldValue("PORT") ?? this.port_);
+        }
+        return {
+            showSettings: this.showSettings_,
+            host: this.host_,
+            user: this.user_,
+            password: this.password_,
+            port: this.port_,
+        };
+    },
+
+    loadExtraState: function (this: any, state: any) {
+        this.showSettings_ = !!state["showSettings"];
+        this.host_ = state["host"] ?? DEFAULT_HOST;
+        this.user_ = state["user"] ?? DEFAULT_USER;
+        this.password_ = state["password"] ?? DEFAULT_PASSWORD;
+        this.port_ = state["port"] ?? DEFAULT_PORT;
+        this.updateShape_();
+    },
+
+    decompose: function (this: any, workspace: Blockly.Workspace) {
+        const containerBlock = workspace.newBlock(
+            "run_script_mutator_container",
+        );
+        (containerBlock as Blockly.BlockSvg).initSvg();
+        if (this.showSettings_) {
+            const itemBlock = workspace.newBlock("run_script_mutator_item");
+            (itemBlock as Blockly.BlockSvg).initSvg();
+            containerBlock
+                .getInput("STACK")!
+                .connection!.connect(itemBlock.previousConnection!);
+        }
+        return containerBlock as Blockly.BlockSvg;
+    },
+
+    compose: function (this: any, containerBlock: Blockly.Block) {
+        const itemBlock = containerBlock.getInputTargetBlock("STACK");
+        this.showSettings_ = !!itemBlock;
+        this.updateShape_();
+    },
+
+    updateShape_: function (this: any) {
+        const hasInput = this.getInput("CONNECTION");
+        if (this.showSettings_ && !hasInput) {
+            this.appendDummyInput("CONNECTION")
+                .appendField("host")
+                .appendField(
+                    new Blockly.FieldTextInput(this.host_, (value: string) => {
+                        this.host_ = value;
+                        return value;
+                    }),
+                    "HOST",
+                )
+                .appendField("user")
+                .appendField(
+                    new Blockly.FieldTextInput(this.user_, (value: string) => {
+                        this.user_ = value;
+                        return value;
+                    }),
+                    "USER",
+                )
+                .appendField("password")
+                .appendField(
+                    new Blockly.FieldTextInput(
+                        this.password_,
+                        (value: string) => {
+                            this.password_ = value;
+                            return value;
+                        },
+                    ),
+                    "PASSWORD",
+                )
+                .appendField("port")
+                .appendField(
+                    new Blockly.FieldNumber(
+                        this.port_,
+                        1,
+                        65535,
+                        1,
+                        (value: string | number) => {
+                            this.port_ = Number(value);
+                            return Number(value);
+                        },
+                    ),
+                    "PORT",
+                );
+        } else if (!this.showSettings_ && hasInput) {
+            // cache the current values before the fields disappear
+            this.host_ = this.getFieldValue("HOST") ?? this.host_;
+            this.user_ = this.getFieldValue("USER") ?? this.user_;
+            this.password_ = this.getFieldValue("PASSWORD") ?? this.password_;
+            this.port_ = Number(this.getFieldValue("PORT") ?? this.port_);
+            this.removeInput("CONNECTION");
+        }
+    },
+};
+
+if (
+    !(Blockly.Extensions as any).isRegistered?.("run_script_connection_mutator")
+) {
+    try {
+        Blockly.Extensions.registerMutator(
+            "run_script_connection_mutator",
+            CONNECTION_MUTATOR_MIXIN as any,
+            undefined,
+            ["run_script_mutator_item"],
+        );
+    } catch (e) {
+        // already registered (e.g. on hot-module-reload) - safe to ignore
+    }
+}
+
+export const runScriptBlocks =
+    Blockly.common.createBlockDefinitionsFromJsonArray([
+        {
+            type: "run_script",
+            message0: "Run script %1",
+            args0: [
+                {
+                    type: "input_value",
+                    name: "SCRIPT",
+                    check: "String",
+                },
+            ],
+            previousStatement: null,
+            nextStatement: null,
+            colour: 45,
+            tooltip:
+                "Connects via SSH to a host and runs the given script. Default host localhost reaches this machine; in Docker it is resolved automatically via SSH_HOST. Use the gear to edit host/user/password/port.",
+            helpUrl: "",
+            mutator: "run_script_connection_mutator",
+        },
+        {
+            type: "run_script_mutator_container",
+            message0: "connection settings %1 %2",
+            args0: [
+                {type: "input_dummy"},
+                {type: "input_statement", name: "STACK"},
+            ],
+            colour: 45,
+            tooltip:
+                "Drag the item below in to use custom connection settings.",
+            helpUrl: "",
+        },
+        {
+            type: "run_script_mutator_item",
+            message0: "use custom connection",
+            previousStatement: null,
+            nextStatement: null,
+            colour: 45,
+            tooltip:
+                "When present, host/user/password/port fields are shown on the block.",
+            helpUrl: "",
+        },
+    ]);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/solid-state-relay-block.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/solid-state-relay-block.ts
@@ -18,8 +18,16 @@ export const setSolidStateRelay =
             previousStatement: null,
             nextStatement: null,
             colour: 355,
+            tooltip: "Turns the Solid-State Relay on or off.",
+            helpUrl: "",
+        },
+        {
+            type: "get_solid_state_relay",
+            message0: "Solid-State Relay is on",
+            output: "Boolean",
+            colour: 355,
             tooltip:
-                "Turns the Solid-State Relay on or off.",
+                "Returns whether the Solid-State Relay is currently turned on.",
             helpUrl: "",
         },
     ]);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/tf-button-block.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/tf-button-block.ts
@@ -1,89 +1,91 @@
 import * as Blockly from "blockly";
 
 export const tfButton = Blockly.common.createBlockDefinitionsFromJsonArray([
-  {
-    type: "tf_button_set_color",
-    message0: "button %1 set color %2",
-    args0: [
-      {
-        type: "field_dropdown",
-        name: "BUTTON_ID",
-        options: [
-          ["1", "1"],
-          ["2", "2"],
-          ["3", "3"],
+    {
+        type: "tf_button_set_color",
+        message0: "button %1 set color %2",
+        args0: [
+            {
+                type: "field_dropdown",
+                name: "BUTTON_ID",
+                options: [
+                    ["1", "1"],
+                    ["2", "2"],
+                    ["3", "3"],
+                ],
+            },
+            {
+                type: "field_colour",
+                name: "COLOR",
+                colour: "#00ff",
+            },
         ],
-      },
-      {
-        type: "field_colour",
-        name: "COLOR",
-        colour: "#00ff",
-      },
-    ],
-    previousStatement: null,
-    nextStatement: null,
-    colour: 20,
-    tooltip: "Setzt die RGB-LED-Farbe des Tinkerforge Buttons.",
-    helpUrl: "",
-  },
-  {
-    type: "tf_button_taster_to_variable",
-    message0: "button %1 as pushbutton |  color %2 write state to %3",
-    args0: [
-      {
-        type: "field_dropdown",
-        name: "BUTTON_ID",
-        options: [
-          ["1", "1"],
-          ["2", "2"],
-          ["3", "3"],
+        previousStatement: null,
+        nextStatement: null,
+        colour: 20,
+        tooltip: "Setzt die RGB-LED-Farbe des Tinkerforge Buttons.",
+        helpUrl: "",
+    },
+    {
+        type: "tf_button_taster_to_variable",
+        message0: "button %1 as pushbutton |  color %2 write state to %3",
+        args0: [
+            {
+                type: "field_dropdown",
+                name: "BUTTON_ID",
+                options: [
+                    ["1", "1"],
+                    ["2", "2"],
+                    ["3", "3"],
+                ],
+            },
+            {
+                type: "field_colour",
+                name: "COLOR",
+                colour: "#00ff00",
+            },
+            {
+                type: "field_variable",
+                name: "VAR",
+                variable: "button_state",
+            },
         ],
-      },
-      {
-        type: "field_colour",
-        name: "COLOR",
-        colour: "#00ff00",
-      },
-      {
-        type: "field_variable",
-        name: "VAR",
-        variable: "button_state",
-      },
-    ],
-    previousStatement: null,
-    nextStatement: null,
-    colour: 20,
-    tooltip: "Setzt die LED-Farbe und schreibt 1 in die Variable, wenn der Button gedrückt ist, sonst 0.",
-    helpUrl: "",
-  },
-  {
-    type: "tf_button_switch_to_variable",
-    message0: "button %1 as switch | color %2 write state to %3",
-    args0: [
-      {
-        type: "field_dropdown",
-        name: "BUTTON_ID",
-        options: [
-          ["1", "1"],
-          ["2", "2"],
-          ["3", "3"],
+        previousStatement: null,
+        nextStatement: null,
+        colour: 20,
+        tooltip:
+            "Setzt die LED-Farbe und schreibt 1 in die Variable, wenn der Button gedrückt ist, sonst 0.",
+        helpUrl: "",
+    },
+    {
+        type: "tf_button_switch_to_variable",
+        message0: "button %1 as switch | color %2 write state to %3",
+        args0: [
+            {
+                type: "field_dropdown",
+                name: "BUTTON_ID",
+                options: [
+                    ["1", "1"],
+                    ["2", "2"],
+                    ["3", "3"],
+                ],
+            },
+            {
+                type: "field_colour",
+                name: "COLOR",
+                colour: "#ff0000",
+            },
+            {
+                type: "field_variable",
+                name: "VAR",
+                variable: "button_state",
+            },
         ],
-      },
-      {
-        type: "field_colour",
-        name: "COLOR",
-        colour: "#ff0000",
-      },
-      {
-        type: "field_variable",
-        name: "VAR",
-        variable: "button_state",
-      },
-    ],
-    previousStatement: null,
-    nextStatement: null,
-    colour: 20,
-    tooltip: "Setzt die LED-Farbe und schreibt den Schalterzustand als 1 oder 0 in die Variable.",
-    helpUrl: "",
-  },
+        previousStatement: null,
+        nextStatement: null,
+        colour: 20,
+        tooltip:
+            "Setzt die LED-Farbe und schreibt den Schalterzustand als 1 oder 0 in die Variable.",
+        helpUrl: "",
+    },
 ]);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/custom-generators.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/custom-generators.ts
@@ -8,6 +8,7 @@ import * as motor_blocks from "./motor-generators";
 import * as playAudioFromSpeech from "./play-audio-from-speech-generator";
 import * as moveToPose from "./pose-generator";
 import * as setSolidStateRelay from "./solid-state-relay-generator";
+import * as runScript from "./run-script-generator";
 import {RESERVED_WORDS} from "./util/reserved-words";
 import * as displayGenerators from "./display-generators";
 
@@ -25,6 +26,7 @@ const generators: typeof pythonGenerator.forBlock = {
     ...playWav,
     ...tfButton,
     ...displayGenerators,
+    ...runScript,
 };
 
 for (const name in generators) {
@@ -37,7 +39,7 @@ pythonGenerator.forBlock["play_audio_from_speech"] =
 pythonGenerator.forBlock["move_to_pose"] = generators["moveToPoseGenerator"];
 
 pythonGenerator.forBlock["set_face_expression"] =
-  generators["setFaceExpressionGenerator"];
+    generators["setFaceExpressionGenerator"];
 
 pythonGenerator.forBlock["show_face_text"] =
-  generators["showFaceTextGenerator"];
+    generators["showFaceTextGenerator"];

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/detectors-generators.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/detectors-generators.ts
@@ -1,9 +1,6 @@
 import {Block} from "blockly/core/block";
 import {pythonGenerator} from "blockly/python";
-import {
-    IMPORT_LOGGING,
-    IMPORT_VISION_PROMPT,
-} from "./util/definitions";
+import {IMPORT_LOGGING, IMPORT_VISION_PROMPT} from "./util/definitions";
 import {
     FACE_DETECTOR_CLASS,
     VISION_HELPER_CLASS,
@@ -13,7 +10,7 @@ function ensureVisionHelper(generator: typeof pythonGenerator): string {
     Object.assign(generator.definitions_, {
         IMPORT_LOGGING,
         IMPORT_VISION_PROMPT,
-        });
+    });
 
     return generator.provideFunction_(
         "VisionHelper",
@@ -101,7 +98,9 @@ export function vision_objects_different(
 
     return [
         `vision = ${className}()`,
-        `${result} = vision.objects_different(${pyString(objectA)}, ${pyString(objectB)})`,
+        `${result} = vision.objects_different(${pyString(objectA)}, ${pyString(
+            objectB,
+        )})`,
         "",
     ].join("\n");
 }

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/display-generators.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/display-generators.ts
@@ -1,8 +1,8 @@
-import { Block } from "blockly/core/block";
-import { pythonGenerator } from "blockly/python";
+import {Block} from "blockly/core/block";
+import {pythonGenerator} from "blockly/python";
 
 function pibDisplayRuntime() {
-  return `
+    return `
 import time
 import rclpy
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
@@ -73,20 +73,20 @@ def _pib_publish_string(pub, value, label="display"):
 }
 
 export function setFaceExpressionGenerator(block: Block) {
-  const expression = block.getFieldValue("EXPRESSION");
+    const expression = block.getFieldValue("EXPRESSION");
 
-  return `${pibDisplayRuntime()}
+    return `${pibDisplayRuntime()}
 _pib_publish_string(_pib_expression_pub, "${expression}", "expression")
 `;
 }
 
 export function showFaceTextGenerator(block: Block) {
-  const rawText = block.getFieldValue("TEXT") || "";
-  const safeText = JSON.stringify(rawText.slice(0, 40));
+    const rawText = block.getFieldValue("TEXT") || "";
+    const safeText = JSON.stringify(rawText.slice(0, 40));
 
-  return `${pibDisplayRuntime()}
+    return `${pibDisplayRuntime()}
 _pib_publish_string(_pib_display_text_pub, ${safeText}[:40], "text")
 `;
 }
 
-export { pythonGenerator };
+export {pythonGenerator};

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/motor-generators.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/motor-generators.ts
@@ -12,7 +12,10 @@ import {
     INIT_GET_JOINT_POSITION_CLIENT,
     INIT_ROS,
 } from "./util/definitions";
-import {APPLY_JOINT_TRAJECTORY_FUNCTION, GET_JOINT_POSITION_FUNCTION} from "./util/function-declarations";
+import {
+    APPLY_JOINT_TRAJECTORY_FUNCTION,
+    GET_JOINT_POSITION_FUNCTION,
+} from "./util/function-declarations";
 
 const motorOptionToMotorName = new Map()
     .set("THUMB_LEFT_OPPOSITION", "thumb_left_opposition")
@@ -92,8 +95,7 @@ export function move_motor(block: Block, generator: typeof pythonGenerator) {
             "get_joint_position",
             GET_JOINT_POSITION_FUNCTION(generator),
         );
-        positionString = 
-            `${getPositionFunctionName}('${selectedMotorName}') + ${positionInput}`;
+        positionString = `${getPositionFunctionName}('${selectedMotorName}') + ${positionInput}`;
     } else {
         throw new Error(`unexpected input-mode: ${modeInput}.`);
     }

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/play-wav-generator.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/play-wav-generator.ts
@@ -14,8 +14,7 @@ import {PLAY_AUDIO_FROM_FILE_FUNCTION} from "./util/function-declarations";
 
 export function play_wav(block: Block, generator: typeof pythonGenerator) {
     const wavFile =
-        block.getFieldValue("WAVFILE") ||
-        "/home/pib/wav-files/R2D2.wav";
+        block.getFieldValue("WAVFILE") || "/home/pib/wav-files/R2D2.wav";
 
     Object.assign(generator.definitions_, {
         IMPORT_RCLPY,

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/pose-generator.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/pose-generator.ts
@@ -9,7 +9,7 @@ import {
     IMPORT_JOINT_TRAJECTORY_MESSAGES,
     INIT_ROS,
     INIT_APPLY_JOINT_TRASJECTORY_CLIENT,
-    IMPORT_POSE_CLIENT
+    IMPORT_POSE_CLIENT,
 } from "./util/definitions";
 import {APPLY_POSE_FUNCTION} from "./util/function-declarations";
 
@@ -30,7 +30,7 @@ export function moveToPoseGenerator(
         CONFIGURE_LOGGING,
         INIT_ROS,
         IMPORT_POSE_CLIENT,
-        INIT_APPLY_JOINT_TRASJECTORY_CLIENT
+        INIT_APPLY_JOINT_TRASJECTORY_CLIENT,
     });
 
     // declare the 'apply_pose'-function

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/run-script-generator.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/run-script-generator.ts
@@ -1,0 +1,42 @@
+import {Block} from "blockly/core/block";
+import {Order, pythonGenerator} from "blockly/python";
+import {
+    CONFIGURE_LOGGING,
+    IMPORT_LOGGING,
+    IMPORT_OS,
+    IMPORT_PARAMIKO,
+    IMPORT_SYS,
+} from "./util/definitions";
+import {RUN_SCRIPT_FUNCTION} from "./util/function-declarations";
+
+export function run_script(block: Block, generator: typeof pythonGenerator) {
+    // extract block-input
+    const script = generator.valueToCode(block, "SCRIPT", Order.NONE) || '""';
+    const host = (block as any).host_ ?? "localhost";
+    const user = (block as any).user_ ?? "pib";
+    const password = (block as any).password_ ?? "pib";
+    const port = (block as any).port_ ?? 22;
+
+    // add definitions to generator
+    Object.assign(generator.definitions_, {
+        IMPORT_SYS,
+        IMPORT_OS,
+        IMPORT_LOGGING,
+        IMPORT_PARAMIKO,
+        CONFIGURE_LOGGING,
+    });
+
+    // declare the 'run_script_over_ssh'-function
+    const functionName = generator.provideFunction_(
+        "run_script_over_ssh",
+        RUN_SCRIPT_FUNCTION(generator),
+    );
+
+    return `${functionName}(${script}, ${generator.quote_(
+        host,
+    )}, ${generator.quote_(user)}, ${generator.quote_(password)}, ${Number(
+        port,
+    )})\n`;
+}
+
+export {pythonGenerator};

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/solid-state-relay-generator.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/solid-state-relay-generator.ts
@@ -9,9 +9,11 @@ import {
     IMPORT_SOLID_STATE_RELAY_STATE,
     INIT_ROS,
     INIT_SET_SOLID_STATE_RELAY_STATE_CLIENT,
-    
 } from "./util/definitions";
-import { SET_SOLID_STATE_RELAY_FUNCTION } from "./util/function-declarations";
+import {
+    SET_SOLID_STATE_RELAY_FUNCTION,
+    GET_SOLID_STATE_RELAY_FUNCTION,
+} from "./util/function-declarations";
 
 export function set_solid_state_relay(
     block: Block,
@@ -39,6 +41,29 @@ export function set_solid_state_relay(
     );
 
     return `${functionName}("${relayStatus}")\n`;
+}
+
+export function get_solid_state_relay(
+    block: Block,
+    generator: typeof pythonGenerator,
+) {
+    // add definitions to generator
+    Object.assign(generator.definitions_, {
+        CONFIGURE_LOGGING,
+        IMPORT_LOGGING,
+        IMPORT_SYS,
+        IMPORT_RCLPY,
+        IMPORT_SOLID_STATE_RELAY_STATE,
+        INIT_ROS,
+    });
+
+    // declare the 'get_solid_state_relay'-function
+    const functionName = generator.provideFunction_(
+        "get_solid_state_relay",
+        GET_SOLID_STATE_RELAY_FUNCTION(generator),
+    );
+
+    return [`${functionName}()`, generator.ORDER_FUNCTION_CALL];
 }
 
 export {pythonGenerator};

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/tf-button-generator.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/tf-button-generator.ts
@@ -2,100 +2,94 @@ import * as Blockly from "blockly";
 import {Block} from "blockly/core/block";
 import {pythonGenerator} from "blockly/python";
 import {
-  CONFIGURE_LOGGING,
-  IMPORT_LOGGING,
-  IMPORT_RCLPY,
-  IMPORT_SYS,
-  IMPORT_TF_BUTTON_SERVICES,
-  IMPORT_TF_BUTTON_BLOCKLY_CLIENT,
-  INIT_ROS,
-  INIT_TF_BUTTON_CLIENTS,
+    CONFIGURE_LOGGING,
+    IMPORT_LOGGING,
+    IMPORT_RCLPY,
+    IMPORT_SYS,
+    IMPORT_TF_BUTTON_SERVICES,
+    IMPORT_TF_BUTTON_BLOCKLY_CLIENT,
+    INIT_ROS,
+    INIT_TF_BUTTON_CLIENTS,
 } from "./util/definitions";
 import {
-  TF_BUTTON_SET_COLOR_FUNCTION,
-  TF_BUTTON_TASTER_FUNCTION,
-  TF_BUTTON_SWITCH_FUNCTION,
+    TF_BUTTON_SET_COLOR_FUNCTION,
+    TF_BUTTON_TASTER_FUNCTION,
+    TF_BUTTON_SWITCH_FUNCTION,
 } from "./util/function-declarations";
 
 function hexToRgb(hex: string): {red: number; green: number; blue: number} {
-  const normalized = hex.replace("#", "");
-  return {
-    red: parseInt(normalized.substring(0, 2), 16),
-    green: parseInt(normalized.substring(2, 4), 16),
-    blue: parseInt(normalized.substring(4, 6), 16),
-  };
+    const normalized = hex.replace("#", "");
+    return {
+        red: parseInt(normalized.substring(0, 2), 16),
+        green: parseInt(normalized.substring(2, 4), 16),
+        blue: parseInt(normalized.substring(4, 6), 16),
+    };
 }
 
 function configureGenerator(generator: typeof pythonGenerator): void {
-  Object.assign(generator.definitions_, {
-    IMPORT_RCLPY,
-    IMPORT_SYS,
-    IMPORT_LOGGING,
-    IMPORT_TF_BUTTON_SERVICES,
-    IMPORT_TF_BUTTON_BLOCKLY_CLIENT,
-    CONFIGURE_LOGGING,
-    INIT_ROS,
-    INIT_TF_BUTTON_CLIENTS,
-  });
+    Object.assign(generator.definitions_, {
+        IMPORT_RCLPY,
+        IMPORT_SYS,
+        IMPORT_LOGGING,
+        IMPORT_TF_BUTTON_SERVICES,
+        IMPORT_TF_BUTTON_BLOCKLY_CLIENT,
+        CONFIGURE_LOGGING,
+        INIT_ROS,
+        INIT_TF_BUTTON_CLIENTS,
+    });
 }
 
 export function tf_button_taster_to_variable(
-  block: Block,
-  generator: typeof pythonGenerator,
+    block: Block,
+    generator: typeof pythonGenerator,
 ) {
-  const buttonId = block.getFieldValue("BUTTON_ID") || "1";
-  const color = block.getFieldValue("COLOR") || "#00ff00";
-  const variableId = block.getFieldValue("VAR");
-  const variableName = generator.nameDB_.getName(
-    variableId,
-    "VARIABLE",
-  );
-  const {red, green, blue} = hexToRgb(color);
+    const buttonId = block.getFieldValue("BUTTON_ID") || "1";
+    const color = block.getFieldValue("COLOR") || "#00ff00";
+    const variableId = block.getFieldValue("VAR");
+    const variableName = generator.nameDB_.getName(variableId, "VARIABLE");
+    const {red, green, blue} = hexToRgb(color);
 
-  configureGenerator(generator);
+    configureGenerator(generator);
 
-  const functionName = generator.provideFunction_(
-    "tf_button_taster",
-    TF_BUTTON_TASTER_FUNCTION(generator),
-  );
+    const functionName = generator.provideFunction_(
+        "tf_button_taster",
+        TF_BUTTON_TASTER_FUNCTION(generator),
+    );
 
-  return `${variableName} = ${functionName}(${buttonId}, ${red}, ${green}, ${blue})\n`;
+    return `${variableName} = ${functionName}(${buttonId}, ${red}, ${green}, ${blue})\n`;
 }
 
 export function tf_button_switch_to_variable(
-  block: Block,
-  generator: typeof pythonGenerator,
+    block: Block,
+    generator: typeof pythonGenerator,
 ) {
-  const buttonId = block.getFieldValue("BUTTON_ID") || "1";
-  const color = block.getFieldValue("COLOR") || "#ff0000";
-  const variableId = block.getFieldValue("VAR");
-  const variableName = generator.nameDB_.getName(
-    variableId,
-    "VARIABLE",
-  );
-  const {red, green, blue} = hexToRgb(color);
+    const buttonId = block.getFieldValue("BUTTON_ID") || "1";
+    const color = block.getFieldValue("COLOR") || "#ff0000";
+    const variableId = block.getFieldValue("VAR");
+    const variableName = generator.nameDB_.getName(variableId, "VARIABLE");
+    const {red, green, blue} = hexToRgb(color);
 
-  configureGenerator(generator);
+    configureGenerator(generator);
 
-  const functionName = generator.provideFunction_(
-    "tf_button_switch",
-    TF_BUTTON_SWITCH_FUNCTION(generator),
-  );
+    const functionName = generator.provideFunction_(
+        "tf_button_switch",
+        TF_BUTTON_SWITCH_FUNCTION(generator),
+    );
 
-  return `${variableName} = ${functionName}(${buttonId}, ${red}, ${green}, ${blue})\n`;
+    return `${variableName} = ${functionName}(${buttonId}, ${red}, ${green}, ${blue})\n`;
 }
 
 export function tf_button_set_color(
-  block: Block,
-  generator: typeof pythonGenerator,
+    block: Block,
+    generator: typeof pythonGenerator,
 ) {
-  const buttonId = block.getFieldValue("BUTTON_ID") || "1";
-  const color = block.getFieldValue("COLOR") || "#00ff00";
-  const {red, green, blue} = hexToRgb(color);
+    const buttonId = block.getFieldValue("BUTTON_ID") || "1";
+    const color = block.getFieldValue("COLOR") || "#00ff00";
+    const {red, green, blue} = hexToRgb(color);
 
-  configureGenerator(generator);
+    configureGenerator(generator);
 
-  return `blockly_client.set_button_color(${buttonId}, ${red}, ${green}, ${blue})\n`;
+    return `blockly_client.set_button_color(${buttonId}, ${red}, ${green}, ${blue})\n`;
 }
 
 export {pythonGenerator};

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/definitions.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/definitions.ts
@@ -6,8 +6,10 @@ export const IMPORT_CV2 = "import cv2";
 export const IMPORT_DEPTHAI = "import depthai as dai";
 export const IMPORT_BLOBCONVERTER = "import blobconverter";
 export const IMPORT_SYS = "import sys";
+export const IMPORT_OS = "import os";
 export const IMPORT_TIME = "import time";
 export const IMPORT_LOGGING = "import logging";
+export const IMPORT_PARAMIKO = "import paramiko";
 export const IMPORT_PLAY_AUDIO_FROM_SPREECH =
     "from datatypes.srv import PlayAudioFromSpeech";
 export const IMPORT_PLAY_AUDIO_FROM_FILE =
@@ -19,9 +21,11 @@ export const IMPORT_GET_JOINT_POSITION =
 export const IMPORT_JOINT_TRAJECTORY_MESSAGES =
     "from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint";
 export const IMPORT_POSE_CLIENT = "from pib_api_client import pose_client";
-export const IMPORT_SET_SOLID_STATE_RELAY = "from datatypes.srv import SetSolidStateRelay";
+export const IMPORT_SET_SOLID_STATE_RELAY =
+    "from datatypes.srv import SetSolidStateRelay";
 export const IMPORT_VISION_PROMPT = "from datatypes.srv import VisionPrompt";
-export const IMPORT_SOLID_STATE_RELAY_STATE = "from datatypes.msg import SolidStateRelayState";
+export const IMPORT_SOLID_STATE_RELAY_STATE =
+    "from datatypes.msg import SolidStateRelayState";
 
 // ros
 
@@ -109,7 +113,7 @@ logging.info(f"service now available")
 `;
 
 export const IMPORT_TF_BUTTON_SERVICES =
-"from button_service.srv import ReadButton";
+    "from button_service.srv import ReadButton";
 
 export const IMPORT_TF_BUTTON_BLOCKLY_CLIENT =
     "from button_service_node_pkg import blockly_client";

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
@@ -154,6 +154,75 @@ def ${generator.FUNCTION_NAME_PLACEHOLDER_}(status: str) -> None:
         logging.error(f"setting solid state relay failed.")
 `;
 
+// get-solid-state-relay
+
+export const GET_SOLID_STATE_RELAY_FUNCTION = (generator: CodeGenerator) => `
+
+def ${generator.FUNCTION_NAME_PLACEHOLDER_}() -> bool:
+
+    received = {}
+
+    def _on_relay_state(msg):
+        received["turned_on"] = msg.turned_on
+
+    subscription = node.create_subscription(
+        SolidStateRelayState, "solid_state_relay_state", _on_relay_state, 10
+    )
+
+    logging.info(f"waiting for solid state relay state...")
+    while "turned_on" not in received:
+        rclpy.spin_once(node)
+    node.destroy_subscription(subscription)
+
+    logging.info(f"solid state relay is {'ON' if received['turned_on'] else 'OFF'}.")
+    return received["turned_on"]
+`;
+
+// run-script
+
+export const RUN_SCRIPT_FUNCTION = (generator: CodeGenerator) => `
+
+def ${generator.FUNCTION_NAME_PLACEHOLDER_}(script: str, host: str, user: str, password: str, port: int) -> None:
+
+    effective_host = host
+    if host in ("localhost", "127.0.0.1"):
+        effective_host = os.environ.get("SSH_HOST", host)
+
+    logging.info(f"connecting to {user}@{effective_host}:{port} via ssh...")
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    try:
+        client.connect(
+            hostname=effective_host,
+            port=port,
+            username=user,
+            password=password,
+            allow_agent=False,
+            look_for_keys=False,
+            timeout=10,
+        )
+
+        logging.info(f"running script on {effective_host}...")
+        stdin, stdout, stderr = client.exec_command(script)
+        exit_status = stdout.channel.recv_exit_status()
+
+        out = stdout.read().decode()
+        err = stderr.read().decode()
+
+        if out:
+            logging.info(out)
+        if err:
+            logging.error(err)
+
+        logging.info(f"script finished with exit code {exit_status}.")
+    except Exception as e:
+        logging.error(f"Cannot connect to {effective_host} via ssh: {e}")
+    finally:
+        client.close()
+`;
+
 // face-detector
 
 export const FACE_DETECTOR_CLASS = (generator: CodeGenerator) => `
@@ -294,8 +363,6 @@ class ${generator.FUNCTION_NAME_PLACEHOLDER_}():
             self.node.destroy_node()
             self.node = None
 `;
-
-
 
 export const TF_BUTTON_TASTER_FUNCTION = (generator: CodeGenerator) => `
 def ${generator.FUNCTION_NAME_PLACEHOLDER_}(button_id: int, red: int, green: int, blue: int) -> int:

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/reserved-words.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/reserved-words.ts
@@ -26,5 +26,5 @@ export const RESERVED_WORDS = [
     "pose_client",
     // solid-state relay
     "SetSolidStateRelay",
-    "set_solid_state_relay_state_client"
+    "set_solid_state_relay_state_client",
 ].join(",");


### PR DESCRIPTION
Implements Jira **PR-1477** — establish pib-backend as the single source of truth for pib-blockly code, syncing to cerebra via an automated Action.

## What this does
- **Back-ports the run-script SSH feature** from cerebra into pib-backend (`run-script-block.ts`, `run-script-generator.ts`, `IMPORT_OS`/`IMPORT_PARAMIKO`, connection-settings mutator). cerebra was *ahead* of pib-backend; this ensures pib-backend is canonical **with all shipped functionality** (no feature loss). Formatting aligned to cerebra's `.prettierrc` so the two trees are byte-identical.
- **Adds `.github/workflows/sync-blockly-to-cerebra.yml`**: on any push (except main) touching `pib_blockly/pib_blockly_server/src/pib-blockly/`, mirrors the tree into cerebra `src/app/program/pib-blockly/` and opens/updates a `maintenance`-labeled PR. Handles adds/mods/**deletions** (`rsync --delete`), creates **no PR when identical**, uses a predictable per-branch sync branch `sync/blockly-from-<branch>` with the open-PR-in-place / reset-after-merge lifecycle from the ticket.

## ⚠️ Required before the sync works
Add a repository secret **`CEREBRA_SYNC_TOKEN`** = a fine-grained PAT / GitHub App token with `contents:write` + `pull-requests:write` on `pib-rocks/cerebra`.

## Tests
- `run_all_tests.sh --skip-docker` on the Pi: **All test steps passed** (Jest blockly generators incl. run-script, pytest integration, Robot E2E).
- `tsc --noEmit` + `npm run build` (webpack) on the blockly server: clean.

Companion PR in cerebra: adds the guard workflow + README banner.