### PR TITLE
PR-1479: Self-heal Jest step on corrupted node_modules (arm64 Pi)

### DIFF
--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -122,6 +122,30 @@ run_jest() {
         # the Pi filesystem), which makes `npx jest` fail with "Permission
         # denied". Restore it defensively before running.
         chmod +x node_modules/.bin/jest 2>/dev/null || true
+
+        # On arm64 (Pi) an npm install is occasionally incomplete: files such as
+        # node_modules/jest-cli/build/index.js go missing, so `npx jest` dies
+        # with "Cannot find module .../jest-cli/build/index.js" (MODULE_NOT_FOUND)
+        # even though the tests themselves are fine. Detect a broken install and
+        # self-heal with one clean reinstall + retry before giving up.
+        if [[ ! -f node_modules/.bin/jest || ! -f node_modules/jest-cli/build/index.js ]]; then
+            echo "Jest install looks incomplete — reinstalling cleanly ..." >&2
+            rm -rf node_modules package-lock.json
+            npm install --silent
+            chmod +x node_modules/.bin/jest 2>/dev/null || true
+        fi
+
+        if npx jest --config jest.config.js; then
+            return 0
+        fi
+
+        # First attempt failed. If it was a broken-install symptom, do a clean
+        # reinstall and retry once. A genuine test failure will fail again here
+        # and still fail the step (no masking of real failures).
+        echo "Jest failed — attempting one clean reinstall + retry ..." >&2
+        rm -rf node_modules package-lock.json
+        npm install --silent
+        chmod +x node_modules/.bin/jest 2>/dev/null || true
         npx jest --config jest.config.js
         return
     fi


### PR DESCRIPTION
Fixes Jira **PR-1479**.

`run_all_tests.sh`'s Jest step falsely reported failure when `tests/blockly_generator/node_modules` was incomplete (arm64 npm install occasionally drops `jest-cli/build/index.js`). `run_jest()` now detects a broken install and does a clean reinstall + single retry before failing; genuine test failures still fail the step.

**Verified on the Pi:** deliberately deleted `node_modules/jest-cli`, then ran the full suite -> self-healed -> **All test steps passed** (exit 0).