### PR TITLE
Fix release-drafter: build notes from develop history (commitish)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,5 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
+        with:
+          # Build the draft from develop's history, not the default branch (main).
+          # PRs are merged to develop continuously; main only receives them on the
+          # rare develop->main sync. Without this, PRs merged to develop after the
+          # last main-merge are missing from the notes.
+          commitish: refs/heads/develop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release notes were missing PRs #216/#217/#218/#220 because release-drafter defaulted to the main branch's history. Sets `commitish: refs/heads/develop` so the draft reflects develop (where PRs land continuously).