### PR TITLE
PR-1480: Fix blank camera image — use ISP output instead of preview

### DIFF
--- a/ros_packages/camera/oak_d_lite/stereo.py
+++ b/ros_packages/camera/oak_d_lite/stereo.py
@@ -84,12 +84,21 @@ class CameraNode(Node):
             self.pipeline = dai.Pipeline()
 
             self.camRgb = self.pipeline.createColorCamera()
-            self.camRgb.setPreviewSize(self.preview_width, self.preview_height)
+            # NOTE: the ColorCamera 'preview' output produces all-black frames on
+            # this OAK-D-Lite + depthai 2.25 setup (auto-exposure never converges
+            # on the preview path — verified: 0/236 frames had content, std=0).
+            # The 'isp' output works correctly with auto-exposure (std~70), so we
+            # stream the full-resolution ISP frame and resize it in software to the
+            # requested preview size. See Jira PR-1480.
+            self.camRgb.setResolution(
+                dai.ColorCameraProperties.SensorResolution.THE_1080_P
+            )
+            self.camRgb.setBoardSocket(dai.CameraBoardSocket.CAM_A)
             self.camRgb.setInterleaved(False)
 
             xoutRgb = self.pipeline.createXLinkOut()
             xoutRgb.setStreamName("rgb")
-            self.camRgb.preview.link(xoutRgb.input)
+            self.camRgb.isp.link(xoutRgb.input)
 
             self.device = dai.Device(self.pipeline)
 
@@ -141,6 +150,17 @@ class CameraNode(Node):
             return
 
         frame = image_rgb.getCvFrame()
+
+        # The ISP output is full sensor resolution (1920x1080). Resize to the
+        # configured preview size so downstream consumers and the JPEG match the
+        # requested dimensions (see PR-1480 — 'preview' output was black).
+        if (
+            frame.shape[1] != self.preview_width
+            or frame.shape[0] != self.preview_height
+        ):
+            frame = cv2.resize(
+                frame, (self.preview_width, self.preview_height)
+            )
 
         self.publish_face_center(frame)
 


### PR DESCRIPTION
Fixes Jira **PR-1480**.

**Root cause (diagnosed on the Pi):** the OAK-D-Lite ColorCamera `preview` output produced all-black frames — auto-exposure never converged on that path (verified 0/236 frames had content, std=0). The `isp` output works correctly with auto-exposure (std~70, real scene).

**Fix:** stream the full-res `isp` output and `cv2.resize` it in software to the configured preview size; face detection now runs on the real frame.

**Verified on the Pi:** rebuilt ros-camera, called `/get_camera_image`, decoded the JPEG → shape 720×1280×3, **std=72.12 (REAL CONTENT)** — previously std=0 (blank). `run_all_tests.sh` on the Pi: **All test steps passed.**