### PR TITLE
PR-1480: Fix blank camera image — bump depthai to 2.30.0.0

### DIFF
--- a/ros_packages/camera/Dockerfile
+++ b/ros_packages/camera/Dockerfile
@@ -33,8 +33,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # opencv-python-headless pinned to 4.x: the latest 5.x release removed
 # cv2.CascadeClassifier from the core module (stereo.py's face detection
 # needs it), causing "module 'cv2' has no attribute 'CascadeClassifier'".
+# depthai pinned to 2.30.0.0: version 2.25.1.0 produced only blank/zero frames
+# from this OAK-D-Lite (IMX214) — verified that the identical pipeline yields a
+# real image on 2.30.0.0 but std=0 (blank) on 2.25.1.0. The working imitation
+# app uses 2.30.0.0. See Jira PR-1480.
 RUN pip install --break-system-packages --no-cache-dir --ignore-installed \
-        depthai==2.25.1.0 \
+        depthai==2.30.0.0 \
         "opencv-python-headless<5"
 
 # stereo.py needs cv2.data.haarcascades at runtime for face detection


### PR DESCRIPTION
Fixes Jira **PR-1480** (the real root cause).

**Root cause:** depthai **2.25.1.0** produces only blank/zero frames from this OAK-D-Lite (IMX214). The hardware is fine — the working `imitation` app uses depthai **2.30.0.0**. Confirmed by running the identical isp pipeline: in the ros-camera container (2.25) → std=0 BLANK; in the imitation venv (2.30) → real image (per-channel std ~64, Laplacian ~400+).

**Fix:** bump `depthai==2.25.1.0` → `2.30.0.0` in ros_packages/camera/Dockerfile.

**Verified on the Pi:** rebuilt ros-camera, `/get_camera_image` JPEG decoded → 1280×720, **std B/G/R=64/65/62, Laplacian=587 → REAL IMAGE** (was uniform green before). `run_all_tests.sh`: **All test steps passed.**

Supersedes the earlier hardware hypothesis in PR-1481 (closing that as not-a-hardware-fault). The PR-1480 isp-output change from before is retained (it is the more robust path).