### PR TITLE
PR-1483: Fix leftover ROS Humble paths after Jazzy migration

### DIFF
--- a/docs/test-basis/infrastructure_and_deployment.md
+++ b/docs/test-basis/infrastructure_and_deployment.md
@@ -158,7 +158,7 @@ flask --app run db upgrade && flask --app run seed_db && flask --app run run --h
 ### ros-programs container command
 
 ```bash
-source /opt/ros/humble/setup.bash &&
+source /opt/ros/jazzy/setup.bash &&
 source /app/ros2_ws/install/setup.bash &&
 ros2 run button_service button_service_node &
 ros2 launch programs launch.py

--- a/ros_packages/button_service/README.md
+++ b/ros_packages/button_service/README.md
@@ -22,7 +22,7 @@ In Docker ist `TF_HOST` abhängig davon, wo `brickd` läuft:
 ## Start
 
 ```bash
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source /app/ros2_ws/install/setup.bash
 ros2 run button_service button_service_node
 ```

--- a/ros_packages/button_service/start_button_service.sh
+++ b/ros_packages/button_service/start_button_service.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source /ros2_ws/install/setup.bash
 
 export TF_HOST=host.docker.internal

--- a/ros_packages/programs/programs/program.py
+++ b/ros_packages/programs/programs/program.py
@@ -145,7 +145,7 @@ class ProgramNode(Node):
                 "bash",
                 "-lc",
                 (
-                    "source /opt/ros/humble/setup.bash && "
+                    "source /opt/ros/jazzy/setup.bash && "
                     "source /app/ros2_ws/install/setup.bash && "
                     f"{PYTHON_BINARY} {UNBUFFERED_OUTPUT_FLAG} {code_python_file_path}"
                 ),

--- a/setup/installation_scripts/local_install.sh
+++ b/setup/installation_scripts/local_install.sh
@@ -47,10 +47,10 @@ function install_ros() {
   sudo apt -qq  update && \
   sudo apt -y -qq  upgrade
 
-  sudo apt -qq install -y ros-humble-ros-base ros-dev-tools && \
-  source /opt/ros/humble/setup.bash && \
-  echo 'source /opt/ros/humble/setup.bash' >> "$HOME/.bashrc"
-  print INFO "Installed ROS2 Humble"
+  sudo apt -qq install -y ros-jazzy-ros-base ros-dev-tools && \
+  source /opt/ros/jazzy/setup.bash && \
+  echo 'source /opt/ros/jazzy/setup.bash' >> "$HOME/.bashrc"
+  print INFO "Installed ROS2 Jazzy"
 
   sudo apt -qq update  && \
   sudo apt -qq -y install python3 python3-pip python3-tk python3-colcon-common-extensions && \
@@ -59,12 +59,12 @@ function install_ros() {
   print INFO "Installed colcon"
 
 
-  sudo apt -qq -y install ros-humble-rosbridge-server
+  sudo apt -qq -y install ros-jazzy-rosbridge-server
   # Install driver for webots connection
-  sudo apt -qq -y install ros-humble-webots-ros2-driver
+  sudo apt -qq -y install ros-jazzy-webots-ros2-driver
 
   print INFO "Installed rosbridge-server and Webots driver"
-  print INFO "Finished installing ROS2 Humble"
+  print INFO "Finished installing ROS2 Jazzy"
 }
 
 
@@ -146,10 +146,10 @@ function install_ros_packages() {
   cd "$HOME" || { print ERROR "${HOME} not found"; return 1; }
 
   # SLAM dependencies (optional)
-#  sudo apt install -y ros-humble-depthai-ros
-#  sudo apt install -y ros-humble-rtabmap
-#  sudo apt install -y ros-humble-rtabmap-launch
-#  sudo apt install -y ros-humble-rtabmap-examples
+#  sudo apt install -y ros-jazzy-depthai-ros
+#  sudo apt install -y ros-jazzy-rtabmap
+#  sudo apt install -y ros-jazzy-rtabmap-launch
+#  sudo apt install -y ros-jazzy-rtabmap-examples
   print INFO "Installed camera dependencies"
 
 
@@ -223,7 +223,7 @@ function install_ros_packages() {
 
 
   cd "$ROS_WORKING_DIR" || { print ERROR "${ROS_WORKING_DIR} not found"; return 1; }
-  source /opt/ros/humble/setup.bash
+  source /opt/ros/jazzy/setup.bash
   colcon build || { print ERROR "could not colcon build packages"; return 1; }
   cd "$HOME" || { print ERROR "${HOME} not found"; return 1; }
 

--- a/setup/setup_files/ros_cerebra_boot.sh
+++ b/setup/setup_files/ros_cerebra_boot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /home/pib/ros_working_dir/ros_config.sh
 sudo service nginx restart
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source /home/pib/ros_working_dir/install/setup.bash
 ros2 launch rosbridge_server rosbridge_websocket_launch.xml


### PR DESCRIPTION
Fixes Jira **PR-1483**.

**Root cause:** running the hello-world program from the Cerebra UI failed with `/opt/ros/humble/setup.bash: No such file or directory` (exit 1) — program.py still sourced the removed Humble path when spawning the user program (leftover from the Jazzy migration).

**Fix:** corrected program.py plus all other repo-wide `ros/humble` leftovers (button_service boot script + README, ros_cerebra_boot.sh, local_install.sh which even installed the `ros-humble-*` distro, docs test-basis). Repo is now grep-clean of ros/humble.

**Verified on the Pi:** rebuilt ros-programs; the exact program.py exec path now runs `source /opt/ros/jazzy/setup.bash && ... python3` → prints 'Hello World', ROS2 message import OK, **EXIT=0** (was exit 1). `run_all_tests.sh`: **All test steps passed.**