### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/ros_packages/button_service/package.xml
+++ b/ros_packages/button_service/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>button_service</name>
-  <version>0.1.0</version>
+  <version>0.5.0</version>
   <description>Tinkerforge RGB LED Button service for pib Blockly blocks.</description>
   <maintainer email="pib@example.local">pib</maintainer>
   <license>AGPL-3.0</license>

--- a/ros_packages/camera/package.xml
+++ b/ros_packages/camera/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>oak_d_lite</name>
-  <version>0.0.0</version>
+  <version>0.5.0</version>
   <description>TODO: Package description</description>
   <maintainer email="iftahnaf@gmail.com">iftach</maintainer>
   <license>TODO: License declaration</license>

--- a/ros_packages/datatypes/package.xml
+++ b/ros_packages/datatypes/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>datatypes</name>
-  <version>0.0.0</version>
+  <version>0.5.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pib@todo.todo">pib</maintainer>
   <license>TODO: License declaration</license>

--- a/ros_packages/display/package.xml
+++ b/ros_packages/display/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>display</name>
-  <version>0.0.0</version>
+  <version>0.5.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pib@todo.todo">pib</maintainer>
   <license>TODO: License declaration</license>

--- a/ros_packages/motors/package.xml
+++ b/ros_packages/motors/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>motors</name>
-  <version>0.0.0</version>
+  <version>0.5.0</version>
   <description>Recieving msgs from cerebra via rosbridge and writing to pib motors using Tinkerforge APIs</description>
   <maintainer email="team@pib.rocks">pib</maintainer>
   <license>Agpl3.0</license>

--- a/ros_packages/pibsim_webots/package.xml
+++ b/ros_packages/pibsim_webots/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>pibsim_webots</name>
-  <version>0.2.1</version>
+  <version>0.5.0</version>
   <description>Simulation package for the open source human robot pib and webots.</description>
   <maintainer email="root@todo.todo">root</maintainer>
   <license>Apache-2.0</license>

--- a/ros_packages/programs/package.xml
+++ b/ros_packages/programs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>programs</name>
-  <version>0.0.0</version>
+  <version>0.5.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pib@todo.todo">pib</maintainer>
   <license>TODO: License declaration</license>

--- a/ros_packages/ros_audio_io/package.xml
+++ b/ros_packages/ros_audio_io/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros_audio_io</name>
-  <version>0.0.0</version>
+  <version>0.5.0</version>
   <description>Publish and listen to DOA data from usb mic array via ROS2 stream, if mic array is connected</description>
   <maintainer email="team@pib.rocks">pib</maintainer>
   <license>Agpl3.0</license>

--- a/ros_packages/voice_assistant/package.xml
+++ b/ros_packages/voice_assistant/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>voice_assistant</name>
-  <version>0.0.0</version>
+  <version>0.5.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pib@todo.todo">pib</maintainer>
   <license>TODO: License declaration</license>


### PR DESCRIPTION
Align in-app version with the published v0.5.0 release tag.