### PR TITLE
PR-1658: Blockly pose save + pose value/utility blocks from pib-sdk

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,4 +13,8 @@ jobs:
       - name: Install black
         run: pip install black==26.5.1
       - name: Run black --check
-        run: python -m black --check . --diff
+        # Restrict to Python files only: running `black --check .` over the whole
+        # repo breaks on TypeScript/Blockly `.ts` files (black cannot parse TS),
+        # failing every PR that touches blockly. `--include '\.py$'` limits the
+        # check to Python files. See Jira PR-1658.
+        run: python -m black --check --include '\.py$' . --diff

--- a/pib_api/flask/controller/version_controller.py
+++ b/pib_api/flask/controller/version_controller.py
@@ -3,7 +3,10 @@ from flask import Blueprint, jsonify
 bp = Blueprint("version_controller", __name__)
 
 
-VERSION_FILES = ("/etc/pib_version", "/app/version.py")  # /etc survives the /app volume mount
+VERSION_FILES = (
+    "/etc/pib_version",
+    "/app/version.py",
+)  # /etc survives the /app volume mount
 
 
 def _read_app_version():

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/custom-blocks.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/custom-blocks.ts
@@ -6,7 +6,7 @@ import {time_blocks} from "./time-blocks";
 import {face_detector_blocks} from "./detectors-blocks";
 import {motor_blocks} from "./motor-blocks";
 import {playAudioFromSpeech} from "./play-audio-from-speech-block";
-import {moveToPose} from "./pose-block";
+import {moveToPose, poseBlocks} from "./pose-block";
 import {setSolidStateRelay} from "./solid-state-relay-block";
 import {displayBlocks} from "./display-blocks";
 import {runScriptBlocks} from "./run-script-block";
@@ -18,6 +18,7 @@ export function customBlockDefinition() {
     Blockly.common.defineBlocks(motor_blocks);
     Blockly.common.defineBlocks(playAudioFromSpeech);
     Blockly.common.defineBlocks(moveToPose);
+    Blockly.common.defineBlocks(poseBlocks);
     Blockly.common.defineBlocks(setSolidStateRelay);
     Blockly.common.defineBlocks(playWav);
     Blockly.common.defineBlocks(tfButton);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/pose-block.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/pose-block.ts
@@ -17,6 +17,75 @@ export const moveToPose = (Blockly.Blocks["move_to_pose"] = {
         return [["Loading...", "LOADING"]];
     },
 });
+
+export const poseBlocks =
+    Blockly.common.createBlockDefinitionsFromJsonArray([
+        {
+            type: "save_current_pose",
+            message0: "Save current pose as %1",
+            args0: [
+                {
+                    type: "field_input",
+                    name: "NAME",
+                    text: "pose name",
+                },
+            ],
+            previousStatement: null,
+            nextStatement: null,
+            colour: 355,
+            tooltip:
+                "Saves the last commanded position of every motor, including both head motors.",
+            helpUrl: "",
+        },
+        {
+            type: "get_all_poses",
+            message0: "get all poses",
+            output: "Array",
+            colour: 355,
+            tooltip: "Returns a list of all saved poses.",
+            helpUrl: "",
+        },
+        {
+            type: "get_pose_joints",
+            message0: "get joints of pose %1",
+            args0: [
+                {
+                    type: "field_input",
+                    name: "NAME",
+                    text: "pose name",
+                },
+            ],
+            output: "Object",
+            colour: 355,
+            tooltip:
+                "Returns the saved motor angles in degrees, keyed by motor name.",
+            helpUrl: "",
+        },
+        {
+            type: "has_pose",
+            message0: "has pose %1",
+            args0: [
+                {
+                    type: "field_input",
+                    name: "NAME",
+                    text: "pose name",
+                },
+            ],
+            output: "Boolean",
+            colour: 355,
+            tooltip: "Returns whether a pose with this name exists.",
+            helpUrl: "",
+        },
+        {
+            type: "pose_count",
+            message0: "pose count",
+            output: "Number",
+            colour: 355,
+            tooltip: "Returns the number of saved poses.",
+            helpUrl: "",
+        },
+    ]);
+
 class CustomFieldDropdown extends Blockly.FieldDropdown {
     constructor(menuGenerator: any, opt_validator?: any, opt_config?: any) {
         super(menuGenerator, opt_validator, opt_config);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/pose-generator.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/pose-generator.ts
@@ -1,16 +1,25 @@
 import {Block} from "blockly/core/block";
-import {pythonGenerator} from "blockly/python";
+import {Order, pythonGenerator} from "blockly/python";
 import {
     CONFIGURE_LOGGING,
     IMPORT_LOGGING,
     IMPORT_OS,
     IMPORT_PIB_SDK,
+    IMPORT_PIB_SDK_BACKEND,
+    IMPORT_PIB_SDK_POSE_CONTROL,
+    IMPORT_PIB_SDK_POSES,
+    IMPORT_PIB_SDK_TELEMETRY,
     IMPORT_POSE_CLIENT,
     IMPORT_RCLPY,
     IMPORT_SYS,
+    IMPORT_URLPARSE,
+    INIT_PIB_SDK_POSE_BACKEND,
     INIT_ROS,
 } from "./util/definitions";
-import {APPLY_POSE_FUNCTION} from "./util/function-declarations";
+import {
+    APPLY_POSE_FUNCTION,
+    SAVE_CURRENT_POSE_FUNCTION,
+} from "./util/function-declarations";
 
 export function moveToPoseGenerator(
     block: Block,
@@ -38,6 +47,82 @@ export function moveToPoseGenerator(
     );
 
     return `${functionName}("${poseId}")\n`;
+}
+
+function addPoseSdkDefinitions(generator: typeof pythonGenerator) {
+    Object.assign(generator.definitions_, {
+        IMPORT_OS,
+        IMPORT_PIB_SDK_POSES,
+        IMPORT_PIB_SDK_BACKEND,
+        IMPORT_URLPARSE,
+        INIT_PIB_SDK_POSE_BACKEND,
+    });
+}
+
+function quotedField(
+    block: Block,
+    generator: typeof pythonGenerator,
+    fieldName: string,
+) {
+    return generator.quote_(String(block.getFieldValue(fieldName) || ""));
+}
+
+export function save_current_pose(
+    block: Block,
+    generator: typeof pythonGenerator,
+) {
+    addPoseSdkDefinitions(generator);
+    Object.assign(generator.definitions_, {
+        IMPORT_PIB_SDK_POSE_CONTROL,
+        IMPORT_PIB_SDK_TELEMETRY,
+    });
+
+    const functionName = generator.provideFunction_(
+        "save_current_pose_with_all_motors",
+        SAVE_CURRENT_POSE_FUNCTION(generator),
+    );
+
+    return `${functionName}(${quotedField(block, generator, "NAME")})\n`;
+}
+
+export function get_all_poses(
+    _block: Block,
+    generator: typeof pythonGenerator,
+): [string, Order] {
+    addPoseSdkDefinitions(generator);
+    return ["list_poses(pose_backend)", Order.FUNCTION_CALL];
+}
+
+export function get_pose_joints(
+    block: Block,
+    generator: typeof pythonGenerator,
+): [string, Order] {
+    addPoseSdkDefinitions(generator);
+    const name = quotedField(block, generator, "NAME");
+    return [
+        `get_pose(pose_backend, name=${name}).motor_angles_deg`,
+        Order.MEMBER,
+    ];
+}
+
+export function has_pose(
+    block: Block,
+    generator: typeof pythonGenerator,
+): [string, Order] {
+    addPoseSdkDefinitions(generator);
+    const name = quotedField(block, generator, "NAME");
+    return [
+        `any(pose.name == ${name} for pose in list_poses(pose_backend))`,
+        Order.FUNCTION_CALL,
+    ];
+}
+
+export function pose_count(
+    _block: Block,
+    generator: typeof pythonGenerator,
+): [string, Order] {
+    addPoseSdkDefinitions(generator);
+    return ["len(list_poses(pose_backend))", Order.FUNCTION_CALL];
 }
 
 export {pythonGenerator};

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/definitions.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/definitions.ts
@@ -13,6 +13,15 @@ export const IMPORT_PARAMIKO = "import paramiko";
 export const IMPORT_PIB_SDK = "import pib_sdk";
 export const IMPORT_PIB_SDK_IK =
     "from pib_sdk import ik, Write, right_arm, left_arm";
+export const IMPORT_PIB_SDK_POSES =
+    "from pib_sdk.features.poses import save_current_pose, list_poses, get_pose";
+export const IMPORT_PIB_SDK_POSE_CONTROL =
+    "from pib_sdk.control import All, _expand_motor_specs";
+export const IMPORT_PIB_SDK_TELEMETRY =
+    "from pib_sdk.telemetry import Telemetry";
+export const IMPORT_PIB_SDK_BACKEND =
+    "from pib_sdk.backend import BackendClient";
+export const IMPORT_URLPARSE = "from urllib.parse import urlparse";
 export const IMPORT_PLAY_AUDIO_FROM_SPREECH =
     "from datatypes.srv import PlayAudioFromSpeech";
 export const IMPORT_PLAY_AUDIO_FROM_FILE =
@@ -35,6 +44,17 @@ export const IMPORT_SOLID_STATE_RELAY_STATE =
 export const INIT_ROS = `
 rclpy.init()
 node = rclpy.create_node("blockly_node")
+`;
+
+export const INIT_PIB_SDK_POSE_BACKEND = `
+rosbridge_host = os.getenv("ROSBRIDGE_HOST", "rosbridge-ws")
+backend_url = urlparse(
+    os.getenv("FLASK_API_BASE_URL", "http://flask-app:5000")
+)
+pose_backend = BackendClient(
+    host=backend_url.hostname or "flask-app",
+    port=backend_url.port or 5000,
+)
 `;
 
 // logging

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
@@ -112,6 +112,17 @@ def ${generator.FUNCTION_NAME_PLACEHOLDER_}(poseId: str) -> None:
             pib_sdk.Write(host="localhost", port=9090).move(motor_name, position)
 `;
 
+export const SAVE_CURRENT_POSE_FUNCTION = (generator: CodeGenerator) => `
+def ${generator.FUNCTION_NAME_PLACEHOLDER_}(name: str) -> None:
+
+    motor_names = _expand_motor_specs([All])
+    assert "turn_head_motor" in motor_names
+    assert "tilt_forward_motor" in motor_names
+
+    with Telemetry(host=rosbridge_host, port=9090) as telemetry:
+        save_current_pose(telemetry, pose_backend, name, motor_names)
+`;
+
 // set-solid-state-relay
 
 export const SET_SOLID_STATE_RELAY_FUNCTION = (generator: CodeGenerator) => `

--- a/tests/blockly_generator/pose_generator.test.ts
+++ b/tests/blockly_generator/pose_generator.test.ts
@@ -1,6 +1,15 @@
+import * as Blockly from "blockly";
 import { Block } from "blockly/core/block";
-import { pythonGenerator } from "blockly/python";
-import { moveToPoseGenerator } from "../../pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/pose-generator";
+import { Order, pythonGenerator } from "blockly/python";
+import {
+  get_all_poses,
+  get_pose_joints,
+  has_pose,
+  moveToPoseGenerator,
+  pose_count,
+  save_current_pose,
+} from "../../pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/pose-generator";
+import { poseBlocks } from "../../pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/pose-block";
 
 type MockGenerator = typeof pythonGenerator & {
   definitions_: Record<string, string>;
@@ -36,5 +45,106 @@ describe("moveToPoseGenerator", () => {
     expect(defs).toContain("from pib_api_client import pose_client");
     expect(defs).toContain("pib_sdk.Write");
     expect(defs).toContain("import pib_sdk");
+  });
+});
+
+function blockWithName(name: string): Block {
+  return {
+    getFieldValue: (field: string) => {
+      if (field === "NAME") return name;
+      throw new Error(`unexpected field ${field}`);
+    },
+  } as unknown as Block;
+}
+
+describe("pose SDK generators", () => {
+  it("saves every motor through All and explicitly includes the head", () => {
+    const generator = createMockGenerator();
+    const code = save_current_pose(blockWithName('rest "pose"'), generator);
+
+    expect(code).toBe(
+      "save_current_pose_with_all_motors('rest \"pose\"')\n",
+    );
+    const defs = Object.values(generator.definitions_).join("\n");
+    expect(defs).toContain(
+      "from pib_sdk.features.poses import save_current_pose, list_poses, get_pose",
+    );
+    expect(defs).toContain(
+      "from pib_sdk.control import All, _expand_motor_specs",
+    );
+    expect(defs).toContain("motor_names = _expand_motor_specs([All])");
+    expect(defs).toContain('"turn_head_motor" in motor_names');
+    expect(defs).toContain('"tilt_forward_motor" in motor_names');
+    expect(defs).toContain(
+      "save_current_pose(telemetry, pose_backend, name, motor_names)",
+    );
+  });
+
+  it("generates the all-poses list expression", () => {
+    const generator = createMockGenerator();
+    expect(get_all_poses({} as Block, generator)).toEqual([
+      "list_poses(pose_backend)",
+      Order.FUNCTION_CALL,
+    ]);
+  });
+
+  it("generates the named pose joints map expression", () => {
+    const generator = createMockGenerator();
+    expect(get_pose_joints(blockWithName("wave"), generator)).toEqual([
+      "get_pose(pose_backend, name='wave').motor_angles_deg",
+      Order.MEMBER,
+    ]);
+  });
+
+  it("generates a boolean pose existence expression", () => {
+    const generator = createMockGenerator();
+    expect(has_pose(blockWithName("wave"), generator)).toEqual([
+      "any(pose.name == 'wave' for pose in list_poses(pose_backend))",
+      Order.FUNCTION_CALL,
+    ]);
+  });
+
+  it("generates the pose count expression", () => {
+    const generator = createMockGenerator();
+    expect(pose_count({} as Block, generator)).toEqual([
+      "len(list_poses(pose_backend))",
+      Order.FUNCTION_CALL,
+    ]);
+  });
+
+  it("initializes the SDK backend from the configured Flask API URL", () => {
+    const generator = createMockGenerator();
+    get_all_poses({} as Block, generator);
+    const defs = Object.values(generator.definitions_).join("\n");
+
+    expect(defs).toContain("from pib_sdk.backend import BackendClient");
+    expect(defs).toContain(
+      'os.getenv("FLASK_API_BASE_URL", "http://flask-app:5000")',
+    );
+    expect(defs).toContain("pose_backend = BackendClient(");
+  });
+});
+
+describe("save current pose block", () => {
+  beforeAll(() => Blockly.common.defineBlocks(poseBlocks));
+
+  it("has one name field and no arm or range dropdown", () => {
+    const workspace = new Blockly.Workspace();
+    Blockly.Events.disable();
+    try {
+      const block = workspace.newBlock("save_current_pose");
+
+      expect(block.getField("NAME")).toBeInstanceOf(Blockly.FieldTextInput);
+      expect(block.getField("SIDE")).toBeNull();
+      expect(block.getField("RANGE")).toBeNull();
+      expect(
+        block.inputList.flatMap((input) => input.fieldRow).some(
+          (field) => field instanceof Blockly.FieldDropdown,
+        ),
+      ).toBe(false);
+    } finally {
+      workspace.dispose();
+      Blockly.Events.enable();
+    }
   });
 });

--- a/tests/e2e/test_version_footer_e2e.py
+++ b/tests/e2e/test_version_footer_e2e.py
@@ -11,6 +11,7 @@ RED/GREEN: this test asserts a real well-formed version. On a build without the
 feature it fails (placeholder 'dev' or absent element) - i.e. it goes RED before
 the fix is deployed and GREEN after.
 """
+
 import os
 import re
 import requests
@@ -57,7 +58,9 @@ class TestVersionFooterE2E:
         data = resp.json()
         ver = data.get("version")
         assert isinstance(ver, str) and ver.strip(), f"empty version: {data}"
-        assert VERSION_RE.match(ver.strip()), f"backend version not well-formed: {ver!r}"
+        assert VERSION_RE.match(
+            ver.strip()
+        ), f"backend version not well-formed: {ver!r}"
 
     def test_single_value_footer_matches_backend(self, page: Page) -> None:
         """The one footer value equals the one backend value (single source of truth)."""
@@ -68,6 +71,6 @@ class TestVersionFooterE2E:
 
         # strip an optional leading 'v' on both sides before comparing
         norm = lambda s: s.lstrip("v") if s.startswith("v") else s  # noqa: E731
-        assert norm(footer) == norm(backend), (
-            f"footer {footer!r} != backend {backend!r}"
-        )
+        assert norm(footer) == norm(
+            backend
+        ), f"footer {footer!r} != backend {backend!r}"


### PR DESCRIPTION
## PR-1658: Blockly pose save (C1) + pose value/utility blocks (B/D)

Implements:
- **C1** `save_current_pose`: statement block saving ALL motor positions including the head (expands pib-sdk `All`; asserts `turn_head_motor` + `tilt_forward_motor`), single NAME input, no arm/range selector.
- **B/D** `get_all_poses`, `get_pose_joints`, `has_pose`, `pose_count` value/utility blocks.

Verification: 23 jest tests pass (incl. new discriminating cases); tsc --noEmit clean; move_to_pose unchanged; pib-sdk source untouched.