### PR TITLE
PR-1660: motor_control as software trajectory controller (multi-point interpolation + blend)

### DIFF
--- a/ros_packages/motors/motors/motor_control.py
+++ b/ros_packages/motors/motors/motor_control.py
@@ -7,6 +7,7 @@ from pib_motors.bricklet import ipcon, connected_enumerate, solid_state_relay_br
 from pib_motors.motor import name_to_motors, motors
 from rclpy.node import Node
 from pib_motors.startup_pose_executor import StartupPoseExecutor
+from pib_motors.trajectory_executor import TrajectoryExecutor, is_software_trajectory
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 
 
@@ -109,6 +110,7 @@ class MotorControl(Node):
         )
 
         self.startup_pose_executor = StartupPoseExecutor(self, motors=motors)
+        self.trajectory_executor = TrajectoryExecutor(self, name_to_motors)
 
         if solid_state_relay_bricklet is None:
             self.get_logger().info(
@@ -179,6 +181,15 @@ class MotorControl(Node):
         jt = request.joint_trajectory
         response.successful = True
         try:
+            if is_software_trajectory(jt):
+                response.successful = self.trajectory_executor.execute(jt)
+                if response.successful:
+                    for motor_name in jt.joint_names:
+                        for motor in name_to_motors[motor_name]:
+                            self.joint_trajectory_publisher.publish(
+                                as_joint_trajectory(motor.name, motor.get_position())
+                            )
+                return response
             for motor_name, position in as_motor_positions(jt):
                 for motor in name_to_motors[motor_name]:
                     self.get_logger().info(

--- a/ros_packages/motors/pib_motors/pib_motors/trajectory_executor.py
+++ b/ros_packages/motors/pib_motors/pib_motors/trajectory_executor.py
@@ -1,0 +1,334 @@
+"""Fixed-rate software trajectory controller for JointTrajectory messages.
+
+Interpolates each joint independently over ``time_from_start`` via-points using
+monotone cubic Hermite (Fritsch–Carlson / PCHIP) so motion blends through
+via-points instead of stopping. Bricklet motion config is sharpened for the
+duration of the trajectory and restored afterwards, following the backup /
+modify / restore-in-finally pattern used by ``StartupPoseExecutor``.
+
+This module is intentionally free of ROS runtime imports so unit tests can
+exercise interpolation and the executor with plain Python fakes.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
+
+DEFAULT_RATE_HZ = 100.0
+# High bricklet motion limits so the software spline, not the servo ramp, shapes speed.
+DEFAULT_SHARP_VELOCITY = 50000
+DEFAULT_SHARP_ACCELERATION = 50000
+DEFAULT_SHARP_DECELERATION = 50000
+
+
+class MotorLike(Protocol):
+    name: str
+
+    def set_position(self, position: int) -> bool: ...
+
+    def get_position(self) -> int: ...
+
+    def get_settings(self) -> dict[str, Any]: ...
+
+    def apply_settings(self, settings_dto: dict[str, Any]) -> bool: ...
+
+
+class LoggerLike(Protocol):
+    def info(self, msg: str) -> Any: ...
+
+    def warn(self, msg: str) -> Any: ...
+
+    def error(self, msg: str) -> Any: ...
+
+
+class NodeLike(Protocol):
+    def get_logger(self) -> LoggerLike: ...
+
+
+MotorLookup = Mapping[str, Sequence[MotorLike]]
+
+
+def duration_to_seconds(time_from_start: Any) -> float:
+    """Convert a ROS Duration, duck-typed duration, or numeric seconds to float."""
+    if time_from_start is None:
+        return 0.0
+    if isinstance(time_from_start, (int, float)):
+        return float(time_from_start)
+    if hasattr(time_from_start, "to_sec"):
+        return float(time_from_start.to_sec())
+    sec = getattr(time_from_start, "sec", 0) or 0
+    nanosec = getattr(time_from_start, "nanosec", None)
+    if nanosec is None:
+        nanosec = getattr(time_from_start, "nanosecs", 0) or 0
+    return float(sec) + float(nanosec) * 1e-9
+
+
+def is_software_trajectory(jt: Any) -> bool:
+    """True when ``jt`` is a timed / waypoint trajectory, not a legacy zip pose.
+
+    Existing pib callers (poses, Blockly, MCP ``apply_pose``) send one
+    JointTrajectoryPoint per motor, each with a single position and no
+    ``time_from_start``. That shape must keep using ``as_motor_positions``.
+
+    A software trajectory is:
+    - any message with a non-zero ``time_from_start``, or
+    - more than one waypoint in the standard JointTrajectory layout
+      (each point carries a position per joint).
+    """
+    points = list(getattr(jt, "points", []) or [])
+    if not points:
+        return False
+    if any(
+        duration_to_seconds(getattr(p, "time_from_start", None)) > 0.0 for p in points
+    ):
+        return True
+    names = list(getattr(jt, "joint_names", []) or [])
+    n_joints = len(names)
+    if len(points) <= 1 or n_joints == 0:
+        return False
+    # Legacy zip: N names, N points, each point has a single position.
+    if len(points) == n_joints and all(
+        len(getattr(p, "positions", []) or []) <= 1 for p in points
+    ):
+        return False
+    return all(len(getattr(p, "positions", []) or []) >= n_joints for p in points)
+
+
+def monotone_cubic_slopes(
+    times: Sequence[float], values: Sequence[float]
+) -> list[float]:
+    """Fritsch–Carlson slopes for a monotone cubic Hermite spline."""
+    n = len(times)
+    if n == 0:
+        return []
+    if n == 1:
+        return [0.0]
+    h = [times[i + 1] - times[i] for i in range(n - 1)]
+    delta = [
+        (values[i + 1] - values[i]) / h[i] if h[i] != 0.0 else 0.0 for i in range(n - 1)
+    ]
+    m = [0.0] * n
+    m[0] = delta[0]
+    m[-1] = delta[-1]
+    for i in range(1, n - 1):
+        if delta[i - 1] * delta[i] <= 0.0:
+            m[i] = 0.0
+        else:
+            w1 = 2.0 * h[i] + h[i - 1]
+            w2 = h[i] + 2.0 * h[i - 1]
+            denom = (w1 / delta[i - 1]) + (w2 / delta[i])
+            m[i] = (w1 + w2) / denom if denom != 0.0 else 0.0
+    return m
+
+
+def interpolate_joint(
+    times: Sequence[float], values: Sequence[float], t: float
+) -> float:
+    """Monotone cubic sample of one joint at time ``t`` (clamped to the spline ends)."""
+    if not times or not values:
+        return 0.0
+    if len(times) == 1 or t <= times[0]:
+        return float(values[0])
+    if t >= times[-1]:
+        return float(values[-1])
+
+    slopes = monotone_cubic_slopes(times, values)
+    i = 0
+    for idx in range(len(times) - 1):
+        if times[idx] <= t <= times[idx + 1]:
+            i = idx
+            break
+    h = times[i + 1] - times[i]
+    if h == 0.0:
+        return float(values[i])
+    s = (t - times[i]) / h
+    s2 = s * s
+    s3 = s2 * s
+    h00 = 2.0 * s3 - 3.0 * s2 + 1.0
+    h10 = s3 - 2.0 * s2 + s
+    h01 = -2.0 * s3 + 3.0 * s2
+    h11 = s3 - s2
+    return (
+        h00 * values[i]
+        + h10 * h * slopes[i]
+        + h01 * values[i + 1]
+        + h11 * h * slopes[i + 1]
+    )
+
+
+def interpolate_positions(
+    joint_names: Sequence[str],
+    times: Sequence[float],
+    positions_by_joint: Mapping[str, Sequence[float]],
+    t: float,
+) -> dict[str, int]:
+    """Return rounded integer targets for every joint at time ``t``."""
+    return {
+        name: int(round(interpolate_joint(times, positions_by_joint[name], t)))
+        for name in joint_names
+    }
+
+
+def parse_joint_trajectory(
+    jt: Any,
+) -> tuple[list[str], list[float], dict[str, list[float]]]:
+    """Unpack ``joint_names`` + waypoint ``positions`` / ``time_from_start``."""
+    names = list(getattr(jt, "joint_names", []) or [])
+    series: dict[str, list[float]] = {name: [] for name in names}
+    timed: list[tuple[float, Any]] = []
+    for point in getattr(jt, "points", []) or []:
+        timed.append(
+            (duration_to_seconds(getattr(point, "time_from_start", None)), point)
+        )
+    timed.sort(key=lambda item: item[0])
+    times: list[float] = []
+    for t, point in timed:
+        times.append(t)
+        positions = list(getattr(point, "positions", []) or [])
+        for i, name in enumerate(names):
+            if i < len(positions):
+                series[name].append(float(positions[i]))
+            elif series[name]:
+                series[name].append(series[name][-1])
+            else:
+                series[name].append(0.0)
+    return names, times, series
+
+
+class TrajectoryExecutor:
+    """Run a JointTrajectory by streaming interpolated ``set_position`` commands."""
+
+    def __init__(
+        self,
+        node: NodeLike | None,
+        motor_lookup: MotorLookup,
+        rate_hz: float = DEFAULT_RATE_HZ,
+        motion_sharp: dict[str, int] | None = None,
+        restore: bool = True,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        clock_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.node = node
+        self.motor_lookup = motor_lookup
+        self.rate_hz = rate_hz if rate_hz > 0 else DEFAULT_RATE_HZ
+        self.motion_sharp = motion_sharp or {
+            "velocity": DEFAULT_SHARP_VELOCITY,
+            "acceleration": DEFAULT_SHARP_ACCELERATION,
+            "deceleration": DEFAULT_SHARP_DECELERATION,
+        }
+        self.restore = restore
+        self.sleep_fn = sleep_fn
+        self.clock_fn = clock_fn
+
+    def execute(self, jt: Any) -> bool:
+        """Execute ``jt``. Multi-point timed paths interpolate; one-point is a single set."""
+        names = list(getattr(jt, "joint_names", []) or [])
+        points = list(getattr(jt, "points", []) or [])
+        if not names or not points:
+            self._log_error("joint trajectory is missing joint_names or points")
+            return False
+
+        motors = self._resolve_motors(names)
+        if motors is None:
+            return False
+
+        if len(points) <= 1 or not is_software_trajectory(jt):
+            return self._execute_single_point(names, points)
+
+        names, times, series = parse_joint_trajectory(jt)
+        original_settings = self._backup_motor_settings(motors)
+        self._sharpen_motion(motors, original_settings)
+        try:
+            return self._run_interpolation_loop(names, times, series)
+        finally:
+            if self.restore:
+                self._restore_settings(motors, original_settings)
+
+    def _execute_single_point(
+        self, names: Sequence[str], points: Sequence[Any]
+    ) -> bool:
+        """Backward-compatible one-shot ``set_position`` (no motion-config change)."""
+        success = True
+        for name, point in zip(names, points):
+            positions = list(getattr(point, "positions", []) or [])
+            if not positions:
+                success = False
+                continue
+            position = int(round(float(positions[0])))
+            for motor in self.motor_lookup[name]:
+                success &= bool(motor.set_position(position))
+        return success
+
+    def _run_interpolation_loop(
+        self,
+        names: Sequence[str],
+        times: Sequence[float],
+        series: Mapping[str, Sequence[float]],
+    ) -> bool:
+        dt = 1.0 / self.rate_hz
+        duration = times[-1] if times else 0.0
+        t0 = self.clock_fn()
+        success = True
+        while True:
+            now = self.clock_fn() - t0
+            targets = interpolate_positions(names, times, series, now)
+            for name in names:
+                position = targets[name]
+                for motor in self.motor_lookup[name]:
+                    success &= bool(motor.set_position(position))
+            if now >= duration:
+                break
+            self.sleep_fn(dt)
+        return success
+
+    def _resolve_motors(self, names: Iterable[str]) -> list[MotorLike] | None:
+        resolved: list[MotorLike] = []
+        seen: set[int] = set()
+        for name in names:
+            if name not in self.motor_lookup:
+                self._log_error(f"unknown joint name '{name}'")
+                return None
+            for motor in self.motor_lookup[name]:
+                identity = id(motor)
+                if identity not in seen:
+                    seen.add(identity)
+                    resolved.append(motor)
+        return resolved
+
+    def _backup_motor_settings(
+        self, motors: Sequence[MotorLike]
+    ) -> dict[str, dict[str, Any]]:
+        original_settings: dict[str, dict[str, Any]] = {}
+        for motor in motors:
+            settings = motor.get_settings()
+            if settings:
+                original_settings[motor.name] = settings.copy()
+        return original_settings
+
+    def _sharpen_motion(
+        self,
+        motors: Sequence[MotorLike],
+        original_settings: Mapping[str, dict[str, Any]],
+    ) -> None:
+        for motor in motors:
+            if motor.name not in original_settings:
+                continue
+            sharp = original_settings[motor.name].copy()
+            sharp["velocity"] = self.motion_sharp["velocity"]
+            sharp["acceleration"] = self.motion_sharp["acceleration"]
+            sharp["deceleration"] = self.motion_sharp["deceleration"]
+            motor.apply_settings(sharp)
+
+    def _restore_settings(
+        self,
+        motors: Sequence[MotorLike],
+        original_settings: Mapping[str, dict[str, Any]],
+    ) -> None:
+        for motor in motors:
+            if motor.name in original_settings:
+                motor.apply_settings(original_settings[motor.name])
+
+    def _log_error(self, message: str) -> None:
+        if self.node is not None:
+            self.node.get_logger().error(message)

--- a/tests/unit/test_trajectory_executor.py
+++ b/tests/unit/test_trajectory_executor.py
@@ -1,0 +1,228 @@
+"""Offline unit tests for TrajectoryExecutor (PR-1660).
+
+Interpolation and the executor are ROS-graph-free: tests use duck-typed
+trajectory messages and a fake Motor. If the module cannot be imported
+(unexpected), skip with a reason instead of failing the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PIB_MOTORS_ROOT = REPO_ROOT / "ros_packages" / "motors" / "pib_motors"
+if str(PIB_MOTORS_ROOT) not in sys.path:
+    sys.path.insert(0, str(PIB_MOTORS_ROOT))
+
+try:
+    from pib_motors.trajectory_executor import (
+        DEFAULT_SHARP_ACCELERATION,
+        DEFAULT_SHARP_DECELERATION,
+        DEFAULT_SHARP_VELOCITY,
+        TrajectoryExecutor,
+        interpolate_joint,
+        interpolate_positions,
+        is_software_trajectory,
+    )
+except ImportError as exc:  # pragma: no cover - unexpected missing module
+    pytest.skip(
+        f"trajectory_executor is not importable: {exc}",
+        allow_module_level=True,
+    )
+
+
+class FakeDuration:
+    def __init__(self, sec: float = 0.0, nanosec: int = 0) -> None:
+        whole = int(sec)
+        frac = sec - whole
+        self.sec = whole
+        self.nanosec = nanosec + int(round(frac * 1e9))
+
+
+class FakePoint:
+    def __init__(self, positions: list[float], time_from_start: float = 0.0) -> None:
+        self.positions = list(positions)
+        self.time_from_start = FakeDuration(time_from_start)
+
+
+class FakeJointTrajectory:
+    def __init__(self, joint_names: list[str], points: list[FakePoint]) -> None:
+        self.joint_names = joint_names
+        self.points = points
+
+
+class FakeMotor:
+    def __init__(self, name: str, settings: dict[str, Any] | None = None) -> None:
+        self.name = name
+        self.positions: list[int] = []
+        self.settings_calls: list[dict[str, Any]] = []
+        self._settings = {
+            "name": name,
+            "visible": True,
+            "invert": False,
+            "rotationRangeMin": -9000,
+            "rotationRangeMax": 9000,
+            "turnedOn": True,
+            "velocity": 4000,
+            "acceleration": 3000,
+            "deceleration": 3000,
+            "pulseWidthMin": 1000,
+            "pulseWidthMax": 2000,
+            "period": 19500,
+        }
+        if settings:
+            self._settings.update(settings)
+        self._position = 0
+
+    def set_position(self, position: int) -> bool:
+        self.positions.append(int(position))
+        self._position = int(position)
+        return True
+
+    def get_position(self) -> int:
+        return self._position
+
+    def get_settings(self) -> dict[str, Any]:
+        return dict(self._settings)
+
+    def apply_settings(self, settings_dto: dict[str, Any]) -> bool:
+        self.settings_calls.append(dict(settings_dto))
+        self._settings = dict(settings_dto)
+        return True
+
+    def check_if_motor_is_connected(self) -> bool:
+        return True
+
+
+class FakeClock:
+    """Deterministic clock: ``sleep`` advances time so tests do not wait."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, dt: float) -> None:
+        self.now += dt
+
+
+def _executor(
+    motors: dict[str, list[FakeMotor]], clock: FakeClock | None = None
+) -> TrajectoryExecutor:
+    clock = clock or FakeClock()
+    return TrajectoryExecutor(
+        node=None,
+        motor_lookup=motors,
+        rate_hz=10.0,
+        sleep_fn=clock.sleep,
+        clock_fn=clock.time,
+    )
+
+
+def test_interpolate_joint_is_linear_between_two_points() -> None:
+    times = [0.0, 1.0]
+    values = [0.0, 100.0]
+    assert interpolate_joint(times, values, 0.0) == pytest.approx(0.0)
+    assert interpolate_joint(times, values, 0.5) == pytest.approx(50.0)
+    assert interpolate_joint(times, values, 1.0) == pytest.approx(100.0)
+    assert interpolate_joint(times, values, 1.5) == pytest.approx(100.0)
+
+
+def test_via_point_mid_segment_is_interpolated_not_clamped() -> None:
+    times = [0.0, 1.0, 2.0]
+    values = [0.0, 100.0, 200.0]
+    mid = interpolate_joint(times, values, 0.5)
+    assert 0.0 < mid < 100.0
+    after_via = interpolate_joint(times, values, 1.2)
+    assert after_via > 100.0
+    targets = interpolate_positions(["elbow"], times, {"elbow": values}, 0.5)
+    assert 0 < targets["elbow"] < 100
+
+
+def test_is_software_trajectory_ignores_legacy_zip_pose() -> None:
+    """N motors / N single-position points / no time → existing as_motor_positions path."""
+    jt = FakeJointTrajectory(
+        ["a", "b"],
+        [FakePoint([10]), FakePoint([20])],
+    )
+    assert is_software_trajectory(jt) is False
+
+
+def test_is_software_trajectory_detects_time_from_start() -> None:
+    jt = FakeJointTrajectory(
+        ["elbow"],
+        [FakePoint([0], 0.0), FakePoint([100], 1.0)],
+    )
+    assert is_software_trajectory(jt) is True
+
+
+def test_multi_point_interpolation_calls_set_position_in_order() -> None:
+    motor = FakeMotor("elbow")
+    clock = FakeClock()
+    executor = _executor({"elbow": [motor]}, clock)
+    jt = FakeJointTrajectory(
+        ["elbow"],
+        [FakePoint([0], 0.0), FakePoint([100], 1.0)],
+    )
+
+    assert executor.execute(jt) is True
+    assert len(motor.positions) >= 2
+    assert motor.positions[0] == 0
+    assert motor.positions[-1] == 100
+    assert motor.positions == sorted(motor.positions)
+
+
+def test_motion_config_is_sharpened_then_restored() -> None:
+    motor = FakeMotor("elbow")
+    original_velocity = motor.get_settings()["velocity"]
+    executor = _executor({"elbow": [motor]})
+    jt = FakeJointTrajectory(
+        ["elbow"],
+        [FakePoint([0], 0.0), FakePoint([50], 0.2)],
+    )
+
+    assert executor.execute(jt) is True
+    assert len(motor.settings_calls) >= 2
+    sharp, restored = motor.settings_calls[0], motor.settings_calls[-1]
+    assert sharp["velocity"] == DEFAULT_SHARP_VELOCITY
+    assert sharp["acceleration"] == DEFAULT_SHARP_ACCELERATION
+    assert sharp["deceleration"] == DEFAULT_SHARP_DECELERATION
+    assert restored["velocity"] == original_velocity
+    assert restored["acceleration"] == 3000
+    assert restored["deceleration"] == 3000
+    assert motor.get_settings()["velocity"] == original_velocity
+
+
+def test_single_point_is_one_set_position_without_sharp_restore() -> None:
+    motor = FakeMotor("elbow")
+    executor = _executor({"elbow": [motor]})
+    jt = FakeJointTrajectory(["elbow"], [FakePoint([42])])
+
+    assert executor.execute(jt) is True
+    assert motor.positions == [42]
+    assert motor.settings_calls == []
+
+
+def test_via_point_blend_does_not_dwell_at_via_point() -> None:
+    motor = FakeMotor("elbow")
+    executor = _executor({"elbow": [motor]})
+    jt = FakeJointTrajectory(
+        ["elbow"],
+        [FakePoint([0], 0.0), FakePoint([100], 1.0), FakePoint([200], 2.0)],
+    )
+
+    assert executor.execute(jt) is True
+    assert any(0 < p < 100 for p in motor.positions), motor.positions
+    assert any(100 < p < 200 for p in motor.positions), motor.positions
+    # After crossing the via-point the stream must keep moving, not hold 100.
+    via_indices = [i for i, p in enumerate(motor.positions) if p == 100]
+    assert via_indices
+    first_via = via_indices[0]
+    tail = motor.positions[first_via + 1 :]
+    assert tail, "trajectory ended at the via-point instead of blending through"
+    assert any(p != 100 for p in tail)


### PR DESCRIPTION
## PR-1660: motor_control as software trajectory controller

Adds fixed-rate software interpolation for multi-point `JointTrajectory` (incl. `time_from_start`)
and via-point blending, backed by the motion-configuration ('sharp'/restore) pattern.

- New `pib_motors/pib_motors/trajectory_executor.py`: monotone cubic Hermite (PCHIP) interpolation,
  100 Hz loop, sharp motion-config before + restore-after (startup-pose pattern), backward-compatible
  single-point fallback.
- `motor_control.py`: delegates software trajectories to the executor; legacy zip-pose / single-point
  path unchanged.
- Tests: `tests/unit/test_trajectory_executor.py` — 8 passing (interpolation, blend, sharp/restore,
  legacy backward-compat).

Merged manually after review (per request).