### PR TITLE
PR-1663: Blockly motor_current value block (motor dropdown -> pib-sdk telemetry)

### DIFF
--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/motor-blocks.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/motor-blocks.ts
@@ -9,6 +9,37 @@ const SIDE_DROPDOWN = {
     ],
 };
 
+const MOTOR_NAME_DROPDOWN_OPTIONS = [
+    ["thumb left opposition", "THUMB_LEFT_OPPOSITION"],
+    ["thumb left stretch", "THUMB_LEFT_STRETCH"],
+    ["index finger left stretch", "INDEX_LEFT_STRETCH"],
+    ["middle finger left stretch", "MIDDLE_LEFT_STRETCH"],
+    ["ring finger left stretch", "RING_LEFT_STRETCH"],
+    ["pinky finger left stretch", "PINKY_LEFT_STRETCH"],
+    ["all fingers left", "ALL_FINGERS_LEFT_STRETCH"],
+    ["thumb right opposition", "THUMB_RIGHT_OPPOSITION"],
+    ["thumb right stretch", "THUMB_RIGHT_STRETCH"],
+    ["index finger right stretch", "INDEX_RIGHT_STRETCH"],
+    ["middle finger right stretch", "MIDDLE_RIGHT_STRETCH"],
+    ["ring finger right stretch", "RING_RIGHT_STRETCH"],
+    ["pinky finger right stretch", "PINKY_RIGHT_STRETCH"],
+    ["all fingers right", "ALL_FINGERS_RIGHT_STRETCH"],
+    ["upper left arm rotation", "UPPER_ARM_LEFT_ROTATION"],
+    ["elbow left", "ELBOW_LEFT"],
+    ["lower left arm rotation", "LOWER_ARM_LEFT_ROTATION"],
+    ["wrist left", "WRIST_LEFT"],
+    ["left shoulder vertical", "SHOULDER_VERTICAL_LEFT"],
+    ["left shoulder horizontal", "SHOULDER_HORIZONTAL_LEFT"],
+    ["upper right arm rotation", "UPPER_ARM_RIGHT_ROTATION"],
+    ["elbow right", "ELBOW_RIGHT"],
+    ["lower right arm rotation", "LOWER_ARM_RIGHT_ROTATION"],
+    ["wrist right", "WRIST_RIGHT"],
+    ["right shoulder vertical", "SHOULDER_VERTICAL_RIGHT"],
+    ["right shoulder horizontal", "SHOULDER_HORIZONTAL_RIGHT"],
+    ["tilt head forward", "TILT_FORWARD_HEAD"],
+    ["turn head", "TURN_HEAD"],
+];
+
 const handPositionTooltip = (axis: string) =>
     `Returns the ${axis} coordinate of the selected hand in millimeters. The value is the position the hand was last commanded to move to, not live encoder feedback. Left/right is from pib's own perspective: imagine standing in front of pib and looking at him (the same binding used across pib part numbering e.g. C35R/C35L).`;
 
@@ -20,36 +51,7 @@ export const motor_blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
             {
                 type: "field_dropdown",
                 name: "MOTORNAME",
-                options: [
-                    ["thumb left opposition", "THUMB_LEFT_OPPOSITION"],
-                    ["thumb left stretch", "THUMB_LEFT_STRETCH"],
-                    ["index finger left stretch", "INDEX_LEFT_STRETCH"],
-                    ["middle finger left stretch", "MIDDLE_LEFT_STRETCH"],
-                    ["ring finger left stretch", "RING_LEFT_STRETCH"],
-                    ["pinky finger left stretch", "PINKY_LEFT_STRETCH"],
-                    ["all fingers left", "ALL_FINGERS_LEFT_STRETCH"],
-                    ["thumb right opposition", "THUMB_RIGHT_OPPOSITION"],
-                    ["thumb right stretch", "THUMB_RIGHT_STRETCH"],
-                    ["index finger right stretch", "INDEX_RIGHT_STRETCH"],
-                    ["middle finger right stretch", "MIDDLE_RIGHT_STRETCH"],
-                    ["ring finger right stretch", "RING_RIGHT_STRETCH"],
-                    ["pinky finger right stretch", "PINKY_RIGHT_STRETCH"],
-                    ["all fingers right", "ALL_FINGERS_RIGHT_STRETCH"],
-                    ["upper left arm rotation", "UPPER_ARM_LEFT_ROTATION"],
-                    ["elbow left", "ELBOW_LEFT"],
-                    ["lower left arm rotation", "LOWER_ARM_LEFT_ROTATION"],
-                    ["wrist left", "WRIST_LEFT"],
-                    ["left shoulder vertical", "SHOULDER_VERTICAL_LEFT"],
-                    ["left shoulder horizontal", "SHOULDER_HORIZONTAL_LEFT"],
-                    ["upper right arm rotation", "UPPER_ARM_RIGHT_ROTATION"],
-                    ["elbow right", "ELBOW_RIGHT"],
-                    ["lower right arm rotation", "LOWER_ARM_RIGHT_ROTATION"],
-                    ["wrist right", "WRIST_RIGHT"],
-                    ["right shoulder vertical", "SHOULDER_VERTICAL_RIGHT"],
-                    ["right shoulder horizontal", "SHOULDER_HORIZONTAL_RIGHT"],
-                    ["tilt head forward", "TILT_FORWARD_HEAD"],
-                    ["turn head", "TURN_HEAD"],
-                ],
+                options: MOTOR_NAME_DROPDOWN_OPTIONS,
             },
             {
                 type: "input_dummy",
@@ -73,6 +75,22 @@ export const motor_blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
         nextStatement: null,
         colour: 355,
         tooltip: "",
+        helpUrl: "",
+    },
+    {
+        type: "motor_current",
+        message0: "Motor current of %1",
+        args0: [
+            {
+                type: "field_dropdown",
+                name: "MOTORNAME",
+                options: MOTOR_NAME_DROPDOWN_OPTIONS,
+            },
+        ],
+        output: "Number",
+        colour: 355,
+        tooltip:
+            "Returns the motor's electrical current draw in milliamps (from the servo bricklet). May be 0 or time out for a motor without a connected bricklet.",
         helpUrl: "",
     },
     {

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/motor-generators.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/motor-generators.ts
@@ -7,6 +7,7 @@ import {
     IMPORT_OS,
     IMPORT_PIB_SDK,
     IMPORT_PIB_SDK_IK,
+    IMPORT_PIB_SDK_TELEMETRY,
     IMPORT_RCLPY,
     IMPORT_SYS,
     INIT_GET_JOINT_POSITION_CLIENT,
@@ -15,6 +16,7 @@ import {
 import {
     APPLY_JOINT_TRAJECTORY_FUNCTION,
     GET_JOINT_POSITION_FUNCTION,
+    GET_MOTOR_CURRENT_MA_FUNCTION,
     SET_HAND_POSITION_XYZ_FUNCTION,
 } from "./util/function-declarations";
 
@@ -103,6 +105,29 @@ export function move_motor(block: Block, generator: typeof pythonGenerator) {
         throw new Error(`unexpected input-mode: ${modeInput}.`);
     }
     return `${functionName}("${selectedMotorName}", ${positionString})\n`;
+}
+
+export function motor_current(
+    block: Block,
+    generator: typeof pythonGenerator,
+): [string, Order] {
+    const motorOption = <string>block.getFieldValue("MOTORNAME");
+    const selectedMotorName: string = motorOptionToMotorName.get(motorOption);
+    if (selectedMotorName === undefined) {
+        throw new Error(`'${motorOption}' is not a valid value for 'MOTORNAME'.`);
+    }
+
+    Object.assign(generator.definitions_, {
+        IMPORT_OS,
+        IMPORT_PIB_SDK_TELEMETRY,
+    });
+
+    const functionName = generator.provideFunction_(
+        "get_motor_current_ma",
+        GET_MOTOR_CURRENT_MA_FUNCTION(generator),
+    );
+
+    return [`${functionName}("${selectedMotorName}")`, Order.FUNCTION_CALL];
 }
 
 export function set_hand_position_xyz(

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
@@ -87,6 +87,18 @@ def ${generator.FUNCTION_NAME_PLACEHOLDER_}(motor_name: str, position: int) -> N
         pib_sdk.Write(host="localhost", port=9090).move(motor_name, position)
 `;
 
+export const GET_MOTOR_CURRENT_MA_FUNCTION = (generator: CodeGenerator) => `
+def ${generator.FUNCTION_NAME_PLACEHOLDER_}(motor_name: str) -> int:
+
+    rosbridge_host = os.getenv("ROSBRIDGE_HOST", "rosbridge-ws")
+    try:
+        with Telemetry(host=rosbridge_host, port=9090) as telemetry:
+            return telemetry.get_current_ma(motor_name)
+    except Exception:
+        with Telemetry(host="localhost", port=9090) as telemetry:
+            return telemetry.get_current_ma(motor_name)
+`;
+
 // pose
 
 export const APPLY_POSE_FUNCTION = (generator: CodeGenerator) => `

--- a/tests/blockly_generator/motor_generator.test.ts
+++ b/tests/blockly_generator/motor_generator.test.ts
@@ -4,6 +4,7 @@ import {
   get_hand_x,
   get_hand_y,
   get_hand_z,
+  motor_current,
   move_motor,
   set_hand_position_xyz,
 } from "../../pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/motor-generators";
@@ -87,6 +88,39 @@ describe("move_motor generator", () => {
     const block = createMotorBlock("TILT_FORWARD_HEAD", "ABSOLUTE");
     const code = move_motor(block, generator);
     expect(code).toContain('"tilt_forward_motor"');
+  });
+});
+
+describe("motor_current generator", () => {
+  it("maps SHOULDER_VERTICAL_LEFT and emits get_current_ma", () => {
+    const generator = createMockGenerator();
+    const block = {
+      getFieldValue: (field: string) => {
+        if (field === "MOTORNAME") return "SHOULDER_VERTICAL_LEFT";
+        throw new Error(`unexpected field ${field}`);
+      },
+    } as unknown as Block;
+
+    const [code, order] = motor_current(block, generator);
+
+    expect(code).toBe('get_motor_current_ma("shoulder_vertical_left")');
+    expect(order).toBe(Order.FUNCTION_CALL);
+    const defs = Object.values(generator.definitions_).join("\n");
+    expect(defs).toContain("from pib_sdk.telemetry import Telemetry");
+    expect(defs).toContain('os.getenv("ROSBRIDGE_HOST", "rosbridge-ws")');
+    expect(defs).toContain("get_current_ma(");
+    expect(defs).toContain('Telemetry(host="localhost", port=9090)');
+  });
+
+  it("rejects an unknown motor option", () => {
+    const generator = createMockGenerator();
+    const block = {
+      getFieldValue: () => "NOT_A_MOTOR",
+    } as unknown as Block;
+
+    expect(() => motor_current(block, generator)).toThrow(
+      "'NOT_A_MOTOR' is not a valid value for 'MOTORNAME'.",
+    );
   });
 });
 


### PR DESCRIPTION
## PR-1663: Blockly motor_current value block

Adds a standalone value block `Motor current of %1` (motor dropdown) that reads a motor's electrical
current in milliamps via `pib_sdk.telemetry.Telemetry.get_current_ma`, so it can be assigned to a
variable / used in conditions/logging.

- Block `motor_current` (Number output, motor dropdown reusing the existing motor list).
- Generator maps dropdown -> pib motor name, emits `telemetry.get_current_ma("<motor>")` with
  ROSBRIDGE_HOST localhost fallback.
- Tests: 25 jest passing (incl. new motor_current cases).

Created for your review; do not auto-merge.