### PR TITLE
PR-1665: fix Jest 'cannot resolve blockly' + robuster run_jest

### DIFF
--- a/tests/blockly_generator/jest.config.js
+++ b/tests/blockly_generator/jest.config.js
@@ -6,7 +6,13 @@ module.exports = {
   testMatch: ["**/*.test.ts"],
   moduleFileExtensions: ["ts", "js"],
   clearMocks: true,
+  // The blocks/generators under test live outside <rootDir> (pib_blockly/...), so Node's
+  // upward node_modules lookup from those files never reaches this package. Resolve every
+  // dependency against <rootDir>/node_modules so a single Blockly copy is used regardless
+  // of cwd or of stray node_modules trees elsewhere in the repo.
+  moduleDirectories: ["node_modules", "<rootDir>/node_modules"],
   moduleNameMapper: {
+    "^blockly$": "<rootDir>/node_modules/blockly",
     "^blockly/(.*)$": "<rootDir>/node_modules/blockly/$1",
   },
   transform: {

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -123,20 +123,28 @@ run_pytest_docker() {
 
 run_jest() {
     cd "${SCRIPT_DIR}/blockly_generator"
-    chmod +x node_modules/.bin/* 2>/dev/null || true
+    # tests/blockly_generator/node_modules is vendored in the repo, so use it as-is and only
+    # install when it is missing. Jest is started via `node .../jest.js` so no executable bit
+    # on node_modules/.bin is required.
+    local jest_cmd='set -e
+if [ ! -f node_modules/jest/bin/jest.js ]; then npm install --silent --no-audit --no-fund; fi
+node node_modules/jest/bin/jest.js --config jest.config.js'
     if command -v docker >/dev/null 2>&1; then
         docker run --rm \
             -v "${REPO_ROOT}:/work" \
             -w "/work/tests/blockly_generator" \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
+            -e npm_config_cache=/tmp/.npm \
             node:18-bookworm \
-            bash -lc 'rm -rf node_modules package-lock.json && npm install --silent && chmod +x node_modules/.bin/* 2>/dev/null || true && npx jest --config jest.config.js'
+            bash -lc "${jest_cmd}"
         return $?
     fi
-    if command -v npm >/dev/null 2>&1; then
-        rm -rf node_modules package-lock.json && npm install --silent && chmod +x node_modules/.bin/* 2>/dev/null || true && npx jest --config jest.config.js
+    if command -v node >/dev/null 2>&1; then
+        bash -c "${jest_cmd}"
         return $?
     fi
-    echo "Neither docker nor npm found — cannot run Jest" >&2
+    echo "Neither docker nor node found — cannot run Jest" >&2
     return 1
 }
 


### PR DESCRIPTION
Fixes Jest 'cannot resolve blockly' on clean checkouts/Pi. Root cause: bare `import * as Blockly from 'blockly'`
in pose-block.ts resolved to an untracked stale Blockly 10.4.3 in pib_blockly_server/node_modules locally, but
missing on clean trees (Pi/container). Added moduleDirectories + explicit `^blockly$` map in jest.config.js so
a single vendored Blockly win. Also fixed tests/run_all_tests.sh run_jest to not wipe vendored node_modules and
to propagate failures (set -e). Host: 5 suites / 25 tests pass.