### PR TITLE
PR-1668: bake default APP_VERSION into flask image (fix /api/version unknown)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
         # Release tag from the git checkout, injected into /etc/pib_version.
         # Override at build time:
         #   docker compose build --build-arg APP_VERSION="$(git tag --points-at HEAD^2)" flask-app
-        APP_VERSION: ""
+        APP_VERSION: ${APP_VERSION:-v0.6.2}
     command: "bash -c 'flask --app run db upgrade && flask --app run seed_db && flask --app run run --host 0.0.0.0'"
     networks:
       - pib-network

--- a/pib_api/flask/Dockerfile
+++ b/pib_api/flask/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.10-slim
 WORKDIR /app
 
 ARG APP_VERSION
-RUN printf '%s\n' "$APP_VERSION" > /etc/pib_version
+# Compose/build-arg supplies the release tag; empty ARG (plain docker build) falls back to dev.
+RUN printf '%s\n' "${APP_VERSION:-dev}" > /etc/pib_version
 
 COPY ./pib_api/flask/requirements.txt /app
 


### PR DESCRIPTION
Fixes /api/version returning 'unknown' on deploy. Adds APP_VERSION build arg for flask-app in docker-compose.yaml (default v0.6.2) and guards the Dockerfile bake to fall back to 'dev' on empty, so /etc/pib_version is non-empty and /api/version matches the frontend footer (single source). 2 files changed (docker-compose.yaml, pib_api/flask/Dockerfile).