### PR TITLE
PR-1671: Blockly set 3-LED button color from a Colour variable (right-hand)

### DIFF
--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/tf-button-block.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/tf-button-block.ts
@@ -27,6 +27,32 @@ export const tfButton = Blockly.common.createBlockDefinitionsFromJsonArray([
         helpUrl: "",
     },
     {
+        type: "tf_button_set_color_from_var",
+        message0: "button %1 set color from variable %2",
+        args0: [
+            {
+                type: "field_dropdown",
+                name: "BUTTON_ID",
+                options: [
+                    ["1", "1"],
+                    ["2", "2"],
+                    ["3", "3"],
+                ],
+            },
+            {
+                type: "input_value",
+                name: "COLOR",
+                check: "Colour",
+            },
+        ],
+        previousStatement: null,
+        nextStatement: null,
+        colour: 20,
+        tooltip:
+            "Setzt die RGB-LED-Farbe des Tinkerforge Buttons aus einer Colour-Variable.",
+        helpUrl: "",
+    },
+    {
         type: "tf_button_taster_to_variable",
         message0: "button %1 as pushbutton |  color %2 write state to %3",
         args0: [

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/tf-button-generator.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/tf-button-generator.ts
@@ -1,6 +1,6 @@
 import * as Blockly from "blockly";
 import {Block} from "blockly/core/block";
-import {pythonGenerator} from "blockly/python";
+import {Order, pythonGenerator} from "blockly/python";
 import {
     CONFIGURE_LOGGING,
     IMPORT_LOGGING,
@@ -90,6 +90,19 @@ export function tf_button_set_color(
     configureGenerator(generator);
 
     return `blockly_client.set_button_color(${buttonId}, ${red}, ${green}, ${blue})\n`;
+}
+
+export function tf_button_set_color_from_var(
+    block: Block,
+    generator: typeof pythonGenerator,
+) {
+    const buttonId = block.getFieldValue("BUTTON_ID") || "1";
+    const colorCode =
+        generator.valueToCode(block, "COLOR", Order.MEMBER) || "'#00ff00'";
+
+    configureGenerator(generator);
+
+    return `blockly_client.set_button_color(${buttonId}, int(${colorCode}[1:3], 16), int(${colorCode}[3:5], 16), int(${colorCode}[5:7], 16))\n`;
 }
 
 export {pythonGenerator};

--- a/tests/blockly_generator/tf_button_generator.test.ts
+++ b/tests/blockly_generator/tf_button_generator.test.ts
@@ -1,0 +1,64 @@
+import { Block } from "blockly/core/block";
+import { Order, pythonGenerator } from "blockly/python";
+import {
+  tf_button_set_color,
+  tf_button_set_color_from_var,
+} from "../../pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/tf-button-generator";
+
+type MockGenerator = typeof pythonGenerator & {
+  definitions_: Record<string, string>;
+  valueToCode: (
+    block: Block,
+    name: string,
+    order: Order,
+  ) => string;
+};
+
+function createMockGenerator(colorCode = "item"): MockGenerator {
+  const definitions: Record<string, string> = {};
+  const generator = Object.create(pythonGenerator) as MockGenerator;
+  generator.definitions_ = definitions;
+  generator.valueToCode = (_block, name, _order) => {
+    if (name === "COLOR") return colorCode;
+    return "";
+  };
+  return generator;
+}
+
+describe("tf_button_set_color_from_var generator", () => {
+  it("emits set_button_color with RGB derived from a colour variable at runtime", () => {
+    const generator = createMockGenerator("item");
+    const block = {
+      getFieldValue: (field: string) => {
+        if (field === "BUTTON_ID") return "2";
+        throw new Error(`unexpected field ${field}`);
+      },
+    } as unknown as Block;
+
+    const code = tf_button_set_color_from_var(block, generator);
+
+    expect(code).toBe(
+      "blockly_client.set_button_color(2, int(item[1:3], 16), int(item[3:5], 16), int(item[5:7], 16))\n",
+    );
+    expect(Object.values(generator.definitions_).join("\n")).toContain(
+      "blockly_client",
+    );
+  });
+});
+
+describe("tf_button_set_color generator", () => {
+  it("still emits static RGB from the inline colour field", () => {
+    const generator = createMockGenerator();
+    const block = {
+      getFieldValue: (field: string) => {
+        if (field === "BUTTON_ID") return "1";
+        if (field === "COLOR") return "#ff0000";
+        throw new Error(`unexpected field ${field}`);
+      },
+    } as unknown as Block;
+
+    const code = tf_button_set_color(block, generator);
+
+    expect(code).toBe("blockly_client.set_button_color(1, 255, 0, 0)\n");
+  });
+});


### PR DESCRIPTION
Adds a Blockly statement block `button %1 set color from variable %2` that sets a pib 3-LED button's RGB color from a Colour VARIABLE on the right-hand side (PR-1671).

- Block `tf_button_set_color_from_var`: BUTTON_ID dropdown (1/2/3) + right-hand `input_value` COLOR (check: Colour).
- Generator reads the colour variable (`valueToCode`) and emits `blockly_client.set_button_color(id, int(<color>[1:3],16), ...)` — RGB derived at runtime from the hex string.
- Existing tf_button_set_color/taster/switch blocks unchanged.

Verified: 6 jest suites / 27 tests pass (incl. new from-var case + regression that the static block is unchanged).