### PR TITLE
PR-1674-backend: persistent Oak-D stereo depth ROS2 interfaces (get_depth_frame, get_distance_at_px)

### DIFF
--- a/ros_packages/camera/oak_d_lite/stereo.py
+++ b/ros_packages/camera/oak_d_lite/stereo.py
@@ -3,8 +3,9 @@ import base64
 import os
 import cv2
 import depthai as dai
+import numpy as np
 import rclpy
-from datatypes.srv import GetCameraImage
+from datatypes.srv import GetCameraImage, GetDepthFrame, GetDistanceAtPx
 from rclpy.node import Node
 from std_msgs.msg import Float32MultiArray, Float64, Int32, Int32MultiArray, String
 
@@ -34,6 +35,7 @@ class CameraNode(Node):
         super().__init__("camera_node")
 
         self.publisher_ = self.create_publisher(String, "camera_topic", 10)
+        self.depth_publisher_ = self.create_publisher(String, "stereo_depth", 10)
         self.face_center_publisher_ = self.create_publisher(
             Float32MultiArray, "face_center", 10
         )
@@ -65,12 +67,22 @@ class CameraNode(Node):
         self.quality_factor = 80
         self.current_image = ""
         self.current_frame = None
+        self.current_depth = None
+        self.pipeline = None
+        self.queue = None
+        self.depth_queue = None
 
         self.camera_available = self.init_pipeline()
 
         if self.camera_available:
             self.get_camera_image_service = self.create_service(
                 GetCameraImage, "get_camera_image", self.get_camera_image_callback
+            )
+            self.get_depth_frame_service = self.create_service(
+                GetDepthFrame, "get_depth_frame", self.get_depth_frame_callback
+            )
+            self.get_distance_at_px_service = self.create_service(
+                GetDistanceAtPx, "get_distance_at_px", self.get_distance_at_px_callback
             )
             self.get_logger().info("Camera service initialized.")
         else:
@@ -98,19 +110,95 @@ class CameraNode(Node):
         response.image_base64 = self.current_image
         return response
 
+    def _encode_depth_frame(self, depth):
+        """Pack uint16 depth (mm) as metadata + base64; returns None on failure."""
+        if depth is None:
+            return None
+        try:
+            depth_u16 = np.ascontiguousarray(depth, dtype=np.uint16)
+            height, width = depth_u16.shape[:2]
+            encoded = base64.b64encode(depth_u16.tobytes()).decode("utf-8")
+            return width, height, "16UC1", encoded
+        except Exception as e:
+            self.get_logger().error(f"Failed to encode depth frame: {e}")
+            return None
+
+    def get_depth_frame_callback(self, request, response):
+        # Read cached depth from the persistent pipeline; do not reconnect.
+        packed = self._encode_depth_frame(self.current_depth)
+        if packed is None:
+            response.width = 0
+            response.height = 0
+            response.encoding = ""
+            response.depth_base64 = ""
+            return response
+        response.width, response.height, response.encoding, response.depth_base64 = (
+            packed
+        )
+        return response
+
+    def get_distance_at_px_callback(self, request, response):
+        # Pixel lookup against cached depth (mm). 0 means invalid / out of range.
+        response.distance_mm = 0.0
+        if self.current_depth is None:
+            return response
+        height, width = self.current_depth.shape[:2]
+        x, y = int(request.x), int(request.y)
+        if x < 0 or y < 0 or x >= width or y >= height:
+            return response
+        response.distance_mm = float(self.current_depth[y, x])
+        return response
+
+    def _init_stereo_depth(self):
+        """Add StereoDepth outputs to the existing pipeline (no extra start)."""
+        mono_left = self.pipeline.create(dai.node.Camera)
+        mono_left.build(dai.CameraBoardSocket.CAM_B)
+        mono_right = self.pipeline.create(dai.node.Camera)
+        mono_right.build(dai.CameraBoardSocket.CAM_C)
+
+        stereo = self.pipeline.create(dai.node.StereoDepth)
+        try:
+            stereo.setDefaultProfilePreset(dai.node.StereoDepth.PresetMode.DEFAULT)
+        except Exception:
+            pass
+        stereo.setLeftRightCheck(True)
+        try:
+            stereo.setDepthAlign(dai.CameraBoardSocket.CAM_A)
+        except Exception:
+            self.get_logger().warning(
+                "Depth-to-RGB align unavailable; using native depth."
+            )
+
+        mono_left_out = mono_left.requestFullResolutionOutput()
+        mono_right_out = mono_right.requestFullResolutionOutput()
+        mono_left_out.link(stereo.left)
+        mono_right_out.link(stereo.right)
+
+        self.depth_queue = stereo.depth.createOutputQueue()
+        self.get_logger().info("Stereo depth outputs added to pipeline.")
+
     def init_pipeline(self) -> bool:
         try:
             # depthai v3 API:
             # Camera node replaces deprecated ColorCamera.
             # XLinkOut is completely removed in DepthAI v3.
             # Output queues are created directly from node outputs via requestIspOutput().
-            # Pipeline is started via pipeline.start().
+            # Pipeline is started via pipeline.start() once (OAK-D-Lite 1-pipeline constraint).
+            # Color ISP and StereoDepth share this single pipeline.
             self.pipeline = dai.Pipeline()
             self.camRgb = self.pipeline.create(dai.node.Camera)
             self.camRgb.build(dai.CameraBoardSocket.CAM_A)
             self.isp_out = self.camRgb.requestIspOutput()
 
             self.queue = self.isp_out.createOutputQueue()
+            self.depth_queue = None
+
+            try:
+                self._init_stereo_depth()
+            except Exception as stereo_exc:
+                self.get_logger().warning(f"Stereo depth not available: {stereo_exc}")
+                self.depth_queue = None
+
             self.pipeline.start()
 
             self.get_logger().info("DepthAI v3 pipeline started successfully.")
@@ -127,6 +215,7 @@ class CameraNode(Node):
             self.get_logger().error(f"Camera not found: {e}")
             self.pipeline = None
             self.queue = None
+            self.depth_queue = None
             return False
 
     def publish_face_center(self, frame):
@@ -162,38 +251,54 @@ class CameraNode(Node):
 
         self.face_center_publisher_.publish(face_msg)
 
-    def timer_callback(self):
-        if not self.queue:
+    def _publish_colorized_depth(self, depth):
+        if self.depth_publisher_.get_subscription_count() == 0:
             return
-
-        image_rgb = self.queue.tryGet()
-        if image_rgb is None:
-            return
-
-        frame = image_rgb.getCvFrame()
-
-        if (
-            frame.shape[1] != self.preview_width
-            or frame.shape[0] != self.preview_height
-        ):
-            frame = cv2.resize(frame, (self.preview_width, self.preview_height))
-
-        self.current_frame = frame
-        self.publish_face_center(frame)
-
-        # Only JPEG/base64 encode when someone is subscribed to camera_topic.
-        # get_camera_image encodes on demand from current_frame instead.
-        if self.publisher_.get_subscription_count() == 0:
-            return
-
-        encoded = self._encode_frame(frame)
+        depth_u16 = np.ascontiguousarray(depth, dtype=np.uint16)
+        depth_vis = cv2.normalize(depth_u16, None, 0, 255, cv2.NORM_MINMAX)
+        colorized = cv2.applyColorMap(depth_vis.astype(np.uint8), cv2.COLORMAP_JET)
+        encoded = self._encode_frame(colorized)
         if encoded is None:
             return
-
-        self.current_image = encoded
         msg = String()
         msg.data = encoded
-        self.publisher_.publish(msg)
+        self.depth_publisher_.publish(msg)
+
+    def timer_callback(self):
+        if self.queue:
+            image_rgb = self.queue.tryGet()
+            if image_rgb is not None:
+                frame = image_rgb.getCvFrame()
+
+                if (
+                    frame.shape[1] != self.preview_width
+                    or frame.shape[0] != self.preview_height
+                ):
+                    frame = cv2.resize(frame, (self.preview_width, self.preview_height))
+
+                self.current_frame = frame
+                self.publish_face_center(frame)
+
+                # Only JPEG/base64 encode when someone is subscribed to camera_topic.
+                # get_camera_image encodes on demand from current_frame instead.
+                if self.publisher_.get_subscription_count() > 0:
+                    encoded = self._encode_frame(frame)
+                    if encoded is not None:
+                        self.current_image = encoded
+                        msg = String()
+                        msg.data = encoded
+                        self.publisher_.publish(msg)
+
+        if not self.depth_queue:
+            return
+
+        depth_packet = self.depth_queue.tryGet()
+        if depth_packet is None:
+            return
+
+        depth = depth_packet.getFrame()
+        self.current_depth = depth
+        self._publish_colorized_depth(depth)
 
     def timer_period_callback(self, msg):
         self.timer_period = msg.data

--- a/ros_packages/camera/package.xml
+++ b/ros_packages/camera/package.xml
@@ -12,6 +12,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
+  <exec_depend>datatypes</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros_packages/datatypes/CMakeLists.txt
+++ b/ros_packages/datatypes/CMakeLists.txt
@@ -35,6 +35,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 	"srv/ProxyRunProgramStop.srv"
 	"srv/ClearPlaybackQueue.srv"
 	"srv/GetCameraImage.srv"
+	"srv/GetDepthFrame.srv"
+	"srv/GetDistanceAtPx.srv"
 	"srv/VisionPrompt.srv"
 	"srv/ApplyJointTrajectory.srv"
 	"srv/GetJointPosition.srv"

--- a/ros_packages/datatypes/srv/GetDepthFrame.srv
+++ b/ros_packages/datatypes/srv/GetDepthFrame.srv
@@ -1,0 +1,7 @@
+# Raw little-endian uint16 depth in millimeters (encoding "16UC1").
+# 0 is invalid / unknown. depth_base64 is numpy-compatible: frombuffer(..., uint16).reshape((height, width))
+---
+int32 width
+int32 height
+string encoding
+string depth_base64

--- a/ros_packages/datatypes/srv/GetDistanceAtPx.srv
+++ b/ros_packages/datatypes/srv/GetDistanceAtPx.srv
@@ -1,0 +1,7 @@
+# Pixel coordinates in the cached depth frame (row y, column x).
+# When depth-to-RGB alignment is available these match the color image.
+int32 x
+int32 y
+---
+# Distance in millimeters. 0.0 means invalid, missing cache, or out of bounds.
+float32 distance_mm

--- a/tests/unit/test_stereo_camera_optimization.py
+++ b/tests/unit/test_stereo_camera_optimization.py
@@ -4,6 +4,7 @@ import os
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
+import base64
 
 import pytest
 
@@ -17,6 +18,38 @@ sys.path.insert(
 
 depthai = pytest.importorskip("depthai")
 rclpy = pytest.importorskip("rclpy")
+
+import types
+
+try:
+    import datatypes.srv as _datatypes_srv
+except ImportError:
+    _datatypes = types.ModuleType("datatypes")
+    _datatypes_srv = types.ModuleType("datatypes.srv")
+    sys.modules["datatypes"] = _datatypes
+    sys.modules["datatypes.srv"] = _datatypes_srv
+
+    class _DummySrv:
+        class Request:
+            pass
+
+        class Response:
+            pass
+
+    _datatypes_srv.GetCameraImage = _DummySrv
+    _datatypes_srv.GetDepthFrame = _DummySrv
+    _datatypes_srv.GetDistanceAtPx = _DummySrv
+else:
+    if not hasattr(_datatypes_srv, "GetDepthFrame"):
+        class _DummySrv:
+            class Request:
+                pass
+
+            class Response:
+                pass
+
+        _datatypes_srv.GetDepthFrame = _DummySrv
+        _datatypes_srv.GetDistanceAtPx = _DummySrv
 
 import numpy as np
 
@@ -93,6 +126,113 @@ class TestStereoCameraOptimization(unittest.TestCase):
             # _encode_frame NOT called since no subscribers on camera_topic
             node._encode_frame.assert_not_called()
             node.publisher_.publish.assert_not_called()
+
+
+class TestStereoDepthInterfaces(unittest.TestCase):
+
+    def _make_node(self):
+        with patch.object(CameraNode, "init_pipeline", return_value=True):
+            node = CameraNode()
+        node.publisher_ = MagicMock()
+        node.publisher_.get_subscription_count.return_value = 0
+        node.depth_publisher_ = MagicMock()
+        node.depth_publisher_.get_subscription_count.return_value = 0
+        node.publish_face_center = MagicMock()
+        return node
+
+    @patch("ros_packages.camera.oak_d_lite.stereo.dai")
+    @patch("ros_packages.camera.oak_d_lite.stereo.os.path.exists", return_value=True)
+    def test_timer_callback_caches_depth_without_publishing(
+        self, mock_exists, mock_dai
+    ):
+        node = self._make_node()
+        node.queue = MagicMock()
+        node.queue.tryGet.return_value = None
+
+        mock_depth = MagicMock()
+        depth = np.array([[0, 1200], [800, 1500]], dtype=np.uint16)
+        mock_depth.getFrame.return_value = depth
+        node.depth_queue = MagicMock()
+        node.depth_queue.tryGet.return_value = mock_depth
+
+        node.timer_callback()
+
+        np.testing.assert_array_equal(node.current_depth, depth)
+        node.depth_publisher_.publish.assert_not_called()
+
+    @patch("ros_packages.camera.oak_d_lite.stereo.dai")
+    @patch("ros_packages.camera.oak_d_lite.stereo.os.path.exists", return_value=True)
+    def test_get_distance_at_px_reads_cached_depth(self, mock_exists, mock_dai):
+        node = self._make_node()
+        node.current_depth = np.array([[0, 1200], [800, 1500]], dtype=np.uint16)
+        node.pipeline = MagicMock()
+
+        request = MagicMock()
+        request.x = 1
+        request.y = 0
+        response = MagicMock()
+        node.get_distance_at_px_callback(request, response)
+
+        self.assertEqual(response.distance_mm, 1200.0)
+        node.pipeline.start.assert_not_called()
+
+    @patch("ros_packages.camera.oak_d_lite.stereo.dai")
+    @patch("ros_packages.camera.oak_d_lite.stereo.os.path.exists", return_value=True)
+    def test_get_depth_frame_encodes_cached_depth(self, mock_exists, mock_dai):
+        node = self._make_node()
+        node.current_depth = np.array([[42, 100], [200, 300]], dtype=np.uint16)
+        node.pipeline = MagicMock()
+
+        request = MagicMock()
+        response = MagicMock()
+        node.get_depth_frame_callback(request, response)
+
+        self.assertEqual(response.width, 2)
+        self.assertEqual(response.height, 2)
+        self.assertEqual(response.encoding, "16UC1")
+        decoded = np.frombuffer(
+            base64.b64decode(response.depth_base64), dtype=np.uint16
+        ).reshape((2, 2))
+        np.testing.assert_array_equal(decoded, node.current_depth)
+        node.pipeline.start.assert_not_called()
+
+    @patch("ros_packages.camera.oak_d_lite.stereo.dai")
+    @patch("ros_packages.camera.oak_d_lite.stereo.os.path.exists", return_value=True)
+    def test_init_pipeline_starts_once_with_stereo(self, mock_exists, mock_dai):
+        with patch.object(CameraNode, "__init__", lambda self: None):
+            node = CameraNode()
+        node.get_logger = MagicMock()
+
+        class _StereoType:
+            class PresetMode:
+                DEFAULT = "DEFAULT"
+
+        pipeline = MagicMock()
+        mock_dai.Pipeline.return_value = pipeline
+        cam = MagicMock()
+        stereo = MagicMock()
+        mock_dai.node.Camera = object()
+        mock_dai.node.StereoDepth = _StereoType
+        mock_dai.CameraBoardSocket.CAM_A = "CAM_A"
+        mock_dai.CameraBoardSocket.CAM_B = "CAM_B"
+        mock_dai.CameraBoardSocket.CAM_C = "CAM_C"
+
+        created = []
+
+        def create(kind):
+            created.append(kind)
+            if kind is _StereoType:
+                return stereo
+            return cam
+
+        pipeline.create.side_effect = create
+
+        ok = CameraNode.init_pipeline(node)
+
+        self.assertTrue(ok)
+        pipeline.start.assert_called_once()
+        self.assertIn(_StereoType, created)
+        stereo.depth.createOutputQueue.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Scope 1 of PR-1674 (camera backend ROS2 depth interfaces).

- New SRVs: GetDepthFrame.srv (width/height/encoding/depth_base64, 16UC1 uint16 mm; 0=invalid), GetDistanceAtPx.srv (int32 x,y -> float32 distance_mm).
- stereo.py: ONE dai.Pipeline (RGB CAM_A + StereoDepth CAM_B/CAM_C), 10-htz timer caches current_depth; services get_depth_frame / get_distance_at_px read the cache (no reconnect). Optional stereo_depth (JPEG base64 preview) publisher gated on subscriber count; get_camera_image/camera_topic unchanged.
- Tests: extended test_stereo_camera_optimization.py (+140) mocking srv types, verifying cache/encode/pixel/OOB/one-pipeline.
