### PR TITLE
PR-1675: Blockly camera depth blocks (get depth frame, depth at x,y)

### DIFF
--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/camera-blocks.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/camera-blocks.ts
@@ -1,0 +1,37 @@
+import * as Blockly from "blockly";
+
+export const camera_blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
+    {
+        type: "camera_get_depth_frame",
+        message0: "get camera depth frame",
+        output: null,
+        colour: 200,
+        tooltip:
+            "Returns the camera depth image as millimetre distances (uint16, height x width). May be empty if no depth data is available.",
+        helpUrl: "",
+    },
+    {
+        type: "camera_get_distance_at_px",
+        message0: "depth at x %1 y %2",
+        args0: [
+            {
+                type: "input_value",
+                name: "X",
+                check: "Number",
+                extensions: "number_validation",
+            },
+            {
+                type: "input_value",
+                name: "Y",
+                check: "Number",
+                extensions: "number_validation",
+            },
+        ],
+        inputsInline: true,
+        output: "Number",
+        colour: 200,
+        tooltip:
+            "Returns the depth distance in millimetres at pixel (x, y). Returns 0 if the pixel is invalid or no depth data is available.",
+        helpUrl: "",
+    },
+]);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/custom-blocks.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-blocks/custom-blocks.ts
@@ -5,6 +5,7 @@ import {playWav} from "./play-wav-block";
 import {time_blocks} from "./time-blocks";
 import {face_detector_blocks} from "./detectors-blocks";
 import {motor_blocks} from "./motor-blocks";
+import {camera_blocks} from "./camera-blocks";
 import {playAudioFromSpeech} from "./play-audio-from-speech-block";
 import {moveToPose, poseBlocks} from "./pose-block";
 import {setSolidStateRelay} from "./solid-state-relay-block";
@@ -16,6 +17,7 @@ export function customBlockDefinition() {
     Blockly.common.defineBlocks(time_blocks);
     Blockly.common.defineBlocks(face_detector_blocks);
     Blockly.common.defineBlocks(motor_blocks);
+    Blockly.common.defineBlocks(camera_blocks);
     Blockly.common.defineBlocks(playAudioFromSpeech);
     Blockly.common.defineBlocks(moveToPose);
     Blockly.common.defineBlocks(poseBlocks);

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/camera-generators.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/camera-generators.ts
@@ -1,0 +1,45 @@
+import {Block} from "blockly/core/block";
+import {Order, pythonGenerator} from "blockly/python";
+import {IMPORT_OS, IMPORT_PIB_SDK_CAMERA} from "./util/definitions";
+import {
+    GET_CAMERA_DEPTH_FRAME_FUNCTION,
+    GET_CAMERA_DISTANCE_AT_PX_FUNCTION,
+} from "./util/function-declarations";
+
+function addCameraDefinitions(generator: typeof pythonGenerator) {
+    Object.assign(generator.definitions_, {
+        IMPORT_OS,
+        IMPORT_PIB_SDK_CAMERA,
+    });
+}
+
+export function camera_get_depth_frame(
+    _block: Block,
+    generator: typeof pythonGenerator,
+): [string, Order] {
+    addCameraDefinitions(generator);
+
+    const functionName = generator.provideFunction_(
+        "get_camera_depth_frame",
+        GET_CAMERA_DEPTH_FRAME_FUNCTION(generator),
+    );
+
+    return [`${functionName}()`, Order.FUNCTION_CALL];
+}
+
+export function camera_get_distance_at_px(
+    block: Block,
+    generator: typeof pythonGenerator,
+): [string, Order] {
+    const xInput = String(generator.valueToCode(block, "X", Order.ATOMIC) || "0");
+    const yInput = String(generator.valueToCode(block, "Y", Order.ATOMIC) || "0");
+
+    addCameraDefinitions(generator);
+
+    const functionName = generator.provideFunction_(
+        "get_camera_distance_at_px",
+        GET_CAMERA_DISTANCE_AT_PX_FUNCTION(generator),
+    );
+
+    return [`${functionName}(${xInput}, ${yInput})`, Order.FUNCTION_CALL];
+}

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/custom-generators.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/custom-generators.ts
@@ -5,6 +5,7 @@ import * as playWav from "./play-wav-generator";
 import * as face_detector_blocks from "./detectors-generators";
 import * as time_blocks from "./time-generators";
 import * as motor_blocks from "./motor-generators";
+import * as camera_blocks from "./camera-generators";
 import * as playAudioFromSpeech from "./play-audio-from-speech-generator";
 import * as moveToPose from "./pose-generator";
 import * as setSolidStateRelay from "./solid-state-relay-generator";
@@ -20,6 +21,7 @@ const generators: typeof pythonGenerator.forBlock = {
     ...face_detector_blocks,
     ...time_blocks,
     ...motor_blocks,
+    ...camera_blocks,
     ...playAudioFromSpeech,
     ...moveToPose,
     ...setSolidStateRelay,

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/definitions.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/definitions.ts
@@ -21,6 +21,8 @@ export const IMPORT_PIB_SDK_TELEMETRY =
     "from pib_sdk.telemetry import Telemetry";
 export const IMPORT_PIB_SDK_BACKEND =
     "from pib_sdk.backend import BackendClient";
+export const IMPORT_PIB_SDK_CAMERA =
+    "from pib_sdk.features.camera import Camera";
 export const IMPORT_URLPARSE = "from urllib.parse import urlparse";
 export const IMPORT_PLAY_AUDIO_FROM_SPREECH =
     "from datatypes.srv import PlayAudioFromSpeech";

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/function-declarations.ts
@@ -99,6 +99,30 @@ def ${generator.FUNCTION_NAME_PLACEHOLDER_}(motor_name: str) -> int:
             return telemetry.get_current_ma(motor_name)
 `;
 
+export const GET_CAMERA_DEPTH_FRAME_FUNCTION = (generator: CodeGenerator) => `
+def ${generator.FUNCTION_NAME_PLACEHOLDER_}():
+
+    rosbridge_host = os.getenv("ROSBRIDGE_HOST", "rosbridge-ws")
+    try:
+        with Camera(host=rosbridge_host, port=9090) as cam:
+            return cam.get_depth_frame()
+    except Exception:
+        with Camera(host="localhost", port=9090) as cam:
+            return cam.get_depth_frame()
+`;
+
+export const GET_CAMERA_DISTANCE_AT_PX_FUNCTION = (generator: CodeGenerator) => `
+def ${generator.FUNCTION_NAME_PLACEHOLDER_}(x, y):
+
+    rosbridge_host = os.getenv("ROSBRIDGE_HOST", "rosbridge-ws")
+    try:
+        with Camera(host=rosbridge_host, port=9090) as cam:
+            return cam.get_distance_at_px(int(x), int(y))
+    except Exception:
+        with Camera(host="localhost", port=9090) as cam:
+            return cam.get_distance_at_px(int(x), int(y))
+`;
+
 // pose
 
 export const APPLY_POSE_FUNCTION = (generator: CodeGenerator) => `

--- a/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/reserved-words.ts
+++ b/pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/util/reserved-words.ts
@@ -24,6 +24,7 @@ export const RESERVED_WORDS = [
     "JointTrajectoryPoint",
     "apply_joint_trajectory_client",
     "get_joint_position_client",
+    "Camera",
     // face detector
     "fd",
     // pose

--- a/tests/blockly_generator/camera_depth_generator.test.ts
+++ b/tests/blockly_generator/camera_depth_generator.test.ts
@@ -1,0 +1,79 @@
+import { Block } from "blockly/core/block";
+import { Order, pythonGenerator } from "blockly/python";
+import {
+  camera_get_depth_frame,
+  camera_get_distance_at_px,
+} from "../../pib_blockly/pib_blockly_server/src/pib-blockly/program-generators/camera-generators";
+
+type MockGenerator = typeof pythonGenerator & {
+  definitions_: Record<string, string>;
+  provideFunction_: (name: string, code: string) => string;
+  valueToCode: (
+    block: Block,
+    name: string,
+    order: Order,
+  ) => string | [string, Order];
+};
+
+function createMockGenerator(): MockGenerator {
+  const definitions: Record<string, string> = {};
+  const generator = Object.create(pythonGenerator) as MockGenerator;
+  generator.definitions_ = definitions;
+  generator.provideFunction_ = (name: string, code: string) => {
+    definitions[`FN_${name}`] = code;
+    return name;
+  };
+  generator.valueToCode = () => "0";
+  return generator;
+}
+
+describe("camera_get_depth_frame generator", () => {
+  it("emits Camera.get_depth_frame via a rosbridge helper", () => {
+    const generator = createMockGenerator();
+    const block = {} as Block;
+
+    const [code, order] = camera_get_depth_frame(block, generator);
+
+    expect(code).toBe("get_camera_depth_frame()");
+    expect(order).toBe(Order.FUNCTION_CALL);
+    const defs = Object.values(generator.definitions_).join("\n");
+    expect(defs).toContain("from pib_sdk.features.camera import Camera");
+    expect(defs).toContain('os.getenv("ROSBRIDGE_HOST", "rosbridge-ws")');
+    expect(defs).toContain("with Camera(host=rosbridge_host, port=9090) as cam:");
+    expect(defs).toContain("return cam.get_depth_frame()");
+    expect(defs).toContain('Camera(host="localhost", port=9090)');
+  });
+});
+
+describe("camera_get_distance_at_px generator", () => {
+  it("emits Camera.get_distance_at_px with x and y inputs", () => {
+    const generator = createMockGenerator();
+    generator.valueToCode = (_block, name) => {
+      if (name === "X") return "120";
+      if (name === "Y") return "80";
+      throw new Error(`unexpected input ${name}`);
+    };
+    const block = {} as Block;
+
+    const [code, order] = camera_get_distance_at_px(block, generator);
+
+    expect(code).toBe("get_camera_distance_at_px(120, 80)");
+    expect(order).toBe(Order.FUNCTION_CALL);
+    const defs = Object.values(generator.definitions_).join("\n");
+    expect(defs).toContain("from pib_sdk.features.camera import Camera");
+    expect(defs).toContain('os.getenv("ROSBRIDGE_HOST", "rosbridge-ws")');
+    expect(defs).toContain("with Camera(host=rosbridge_host, port=9090) as cam:");
+    expect(defs).toContain("return cam.get_distance_at_px(int(x), int(y))");
+    expect(defs).toContain('Camera(host="localhost", port=9090)');
+  });
+
+  it("defaults missing x/y inputs to 0", () => {
+    const generator = createMockGenerator();
+    generator.valueToCode = () => "";
+    const block = {} as Block;
+
+    const [code] = camera_get_distance_at_px(block, generator);
+
+    expect(code).toBe("get_camera_distance_at_px(0, 0)");
+  });
+});


### PR DESCRIPTION
Adds two Blockly camera-depth blocks that call the pib_sdk Camera depth API (pib-sdk 0.5.0, PR-1674).

- `camera_get_depth_frame`: 'get camera depth frame' reporter -> cam.get_depth_frame()
- `camera_get_distance_at_px`: 'depth at x %1 y %2' (Number mm) -> cam.get_distance_at_px(int(x),int(y))

Calls pib_sdk.features.camera.Camera over rosbridge (ROSBRIDGE_HOST default, localhost fallback); registered in custom-blocks/custom-generators; Camera added to reserved words.

Files: camera-blocks.ts, camera-generators.ts, camera_depth_generator.test.ts + registration/helpers.
Verified: 7 jest suites / 30 tests pass. pib_sdk untouched.